### PR TITLE
Shared scoring module, PR prediction enrichment, and dashboard updates

### DIFF
--- a/gather-and-rank.js
+++ b/gather-and-rank.js
@@ -6,6 +6,7 @@ const fetch = (...args) =>
 const fs = require('fs');
 const path = require('path');
 const { v4: uuidv4 } = require('uuid');
+const { calculateScore } = require('./score');
 
 // ----- nodejs helper variables -----
 _cReset = '\x1b[0m';
@@ -906,16 +907,7 @@ _processProjects().finally(() => {
       }
 
       // calculate the user score
-      _RESULTS.users[user].score =
-        (_RESULTS.users[user].loc > 1000000
-          ? _RESULTS.users[user].loc / 800
-          : _RESULTS.users[user].loc / 100) +
-        _RESULTS.users[user].filesTouched / 100 +
-        _RESULTS.users[user].pullRequests * 15 +
-        _RESULTS.users[user].commits / 100 +
-        (_RESULTS.users[user].commits / _RESULTS.commitsPerPullRequest) * 10 +
-        // (_RESULTS.users[user].pullRequests ? _RESULTS.users[user].commits / _RESULTS.users[user].pullRequests / 10 : 0) + // account for divide by zero
-        _RESULTS.users[user].reviews * 10;
+      _RESULTS.users[user].score = calculateScore(_RESULTS.users[user]);
 
       // make sure that the score is defined
       if (!_RESULTS.users[user].score) {
@@ -934,8 +926,6 @@ _processProjects().finally(() => {
     if (!_RESULTS.teamScore) {
       _RESULTS.teamScore = 0;
     }
-
-    _RESULTS.teamScore /= _RESULTS.activeUsers;
 
     // Convert the _RESULTS.users object to an array of user objects
     const usersArray = Object.values(_RESULTS.users);
@@ -961,11 +951,19 @@ _processProjects().finally(() => {
           if (usersArray[index]?.score > 0) {
             // if the ignored user had a score, it was previously counted as active, so reduce
             _RESULTS.activeUsers--;
+            _RESULTS.teamScore -= usersArray[index].score;
           }
 
           usersArray.splice(index, 1);
         }
       });
+    }
+
+    // calculate the team score average from the remaining active users
+    if (_RESULTS.activeUsers > 0) {
+      _RESULTS.teamScore /= _RESULTS.activeUsers;
+    } else {
+      _RESULTS.teamScore = 0;
     }
 
     // Assign the sorted object back to _RESULTS.users

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "format": "npx prettier --write . $@",
     "test": "echo \"Error: no test specified\" && exit 1",
     "config": "node configurator.js $1",
-    "start": "rm -rf .results_history/*.csv && rm -rf .results_history/combined_results.json && node gather-and-rank.js && node results-combiner.js && node results-charter.js && node results-team-charter.js && node active-users-by-date.js && node results-dashboard.js",
+    "start": "rm -rf .results_history/*.csv && rm -rf .results_history/combined_results.json && node gather-and-rank.js && node results-enrich.js && node results-combiner.js && node results-charter.js && node results-team-charter.js && node active-users-by-date.js && node results-dashboard.js",
     "gather": "node gather-and-rank.js",
     "combine": "rm -rf .results_history/combined_results.json && node results-combiner.js",
     "chart": "rm -rf .results_history/*.csv && node results-charter.js; node results-team-charter.js; node results-dashboard.js",
     "dashboard": "node results-dashboard.js",
     "reindex": "node results-reindexer.js",
+    "enrich": "node results-enrich.js",
     "help": "node help.js"
   },
   "repository": {

--- a/results-dashboard.js
+++ b/results-dashboard.js
@@ -55,6 +55,7 @@ months.forEach(month => {
       score: user.score || 0,
       commits: user.commits || 0,
       pullRequests: user.pullRequests || 0,
+      predictedPullRequests: user.predictedPullRequests || 0,
       reviews: user.reviews || 0,
       loc: user.loc || 0,
       filesTouched: user.filesTouched || 0,
@@ -700,7 +701,7 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
   const ALL_MONTHS = DATA.months;
   const METRICS = [
     { key: 'score',        label: 'Score',         color: '#00ddcc', format: v => v.toFixed(0) },
-    { key: 'pullRequests', label: 'Pull Requests',  color: '#00aaff', format: v => v.toFixed(0) },
+    { key: 'effectivePRs', label: 'Pull Requests',  color: '#00aaff', format: v => v.toFixed(0), dataKey: 'effectivePR' },
     { key: 'reviews',      label: 'Reviews',        color: '#cc66ff', format: v => v.toFixed(0) },
     { key: 'commits',      label: 'Commits',        color: '#22cc44', format: v => v.toFixed(0) },
     { key: 'loc',          label: 'Lines of Code',  color: '#ff8844', format: v => v >= 1000 ? (v/1000).toFixed(1)+'k' : v.toFixed(0) },
@@ -725,14 +726,16 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
 
   function getUserTotals(userName, months) {
     const ud = DATA.users[userName];
-    if (!ud) return { score:0, commits:0, pullRequests:0, reviews:0, loc:0, filesTouched:0 };
-    const totals = { score:0, commits:0, pullRequests:0, reviews:0, loc:0, filesTouched:0 };
+    if (!ud) return { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, loc:0, filesTouched:0 };
+    const totals = { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, loc:0, filesTouched:0 };
     months.forEach(m => {
       const d = ud.data[m];
       if (d) {
         totals.score += d.score;
         totals.commits += d.commits;
         totals.pullRequests += d.pullRequests;
+        totals.predictedPullRequests += d.predictedPullRequests || 0;
+        totals.effectivePRs += d.pullRequests > 0 ? d.pullRequests : (d.predictedPullRequests || 0);
         totals.reviews += d.reviews;
         totals.loc += d.loc;
         totals.filesTouched += d.filesTouched;
@@ -884,7 +887,12 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
         const ud = DATA.users[user.name];
         return {
           label: user.name.split(' ').map(w => w[0].toUpperCase() + w.slice(1)).join(' '),
-          data: months.map(m => ud.data[m] ? ud.data[m][metric.key] : 0),
+          data: months.map(m => {
+            const d = ud.data[m];
+            if (!d) return 0;
+            if (metric.key === 'effectivePRs') return d.pullRequests > 0 ? d.pullRequests : (d.predictedPullRequests || 0);
+            return d[metric.key] || 0;
+          }),
           borderColor: CHART_COLORS[ui % CHART_COLORS.length],
           backgroundColor: CHART_COLORS[ui % CHART_COLORS.length] + '15',
           fill: false
@@ -993,7 +1001,12 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
 
     METRICS.forEach(m => {
       const canvas = document.getElementById('pchart-' + m.key);
-      const data = months.map(mo => ud && ud.data[mo] ? ud.data[mo][m.key] : 0);
+      const data = months.map(mo => {
+        const d = ud && ud.data[mo];
+        if (!d) return 0;
+        if (m.key === 'effectivePRs') return d.pullRequests > 0 ? d.pullRequests : (d.predictedPullRequests || 0);
+        return d[m.key] || 0;
+      });
       profileCharts[m.key] = new Chart(canvas, makeChartConfig(
         months,
         [{

--- a/results-enrich.js
+++ b/results-enrich.js
@@ -1,0 +1,221 @@
+/**
+ * results-enrich.js
+ *
+ * Two-pass enrichment of historical results to synthesize predicted pull
+ * requests for periods where PR data is missing or sparse.
+ *
+ * Pass 1 — Learn:
+ *   Scans all results files to compute each user's personal commits-per-PR
+ *   ratio from months where they have real PR data. Also computes a team-wide
+ *   average ratio as a fallback.
+ *
+ * Pass 2 — Enrich:
+ *   For each user in each month: if they have commits but zero PRs, uses
+ *   their personal ratio (or the team average if no personal data exists)
+ *   to synthesize predictedPullRequests. Recalculates scores using the
+ *   shared scoring module.
+ *
+ * Usage:
+ *   node results-enrich.js          # enrich all files
+ *   node results-enrich.js --dry    # preview without writing
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { calculateScore } = require('./score');
+
+// ─── Terminal colors ────────────────────────────────────────────────────────
+
+const C = {
+  reset: '\x1b[0m',
+  dim: '\x1b[2m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  blue: '\x1b[34m',
+  cyan: '\x1b[36m',
+  red: '\x1b[31m',
+  gray: '\x1b[90m',
+  magenta: '\x1b[35m',
+};
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+
+const dryRun = process.argv.includes('--dry');
+const resultsDir = path.join(__dirname, '.results_history');
+
+const files = fs
+  .readdirSync(resultsDir)
+  .filter(f => f.endsWith('.json') && f !== 'combined_results.json')
+  .sort();
+
+if (files.length === 0) {
+  console.log(`${C.yellow}No results files found.${C.reset}`);
+  process.exit(0);
+}
+
+console.log(`\n${C.cyan}Repo Hero — PR Enrichment${C.reset}`);
+if (dryRun) {
+  console.log(`${C.yellow}DRY RUN — no files will be modified${C.reset}`);
+}
+
+// ─── Pass 1: Learn per-user commits-per-PR ratios ───────────────────────────
+
+console.log(`\n${C.blue}Pass 1:${C.reset} Learning commits-per-PR ratios...`);
+
+// Accumulate totals from months where the user has real PR data
+const userStats = {}; // { name: { commits: N, pullRequests: N } }
+
+files.forEach(file => {
+  const data = JSON.parse(fs.readFileSync(path.join(resultsDir, file), 'utf8'));
+  if (!data.users || !Array.isArray(data.users)) return;
+
+  data.users.forEach(user => {
+    const prs = user.pullRequests || 0;
+    const commits = user.commits || 0;
+
+    if (prs > 0 && commits > 0) {
+      if (!userStats[user.name]) {
+        userStats[user.name] = { commits: 0, pullRequests: 0 };
+      }
+      userStats[user.name].commits += commits;
+      userStats[user.name].pullRequests += prs;
+    }
+  });
+});
+
+// Compute per-user ratios
+const userRatios = {}; // { name: commitsPerPR }
+let teamTotalCommits = 0;
+let teamTotalPRs = 0;
+
+Object.entries(userStats).forEach(([name, stats]) => {
+  userRatios[name] = stats.commits / stats.pullRequests;
+  teamTotalCommits += stats.commits;
+  teamTotalPRs += stats.pullRequests;
+});
+
+const teamAvgRatio = teamTotalPRs > 0 ? teamTotalCommits / teamTotalPRs : 0;
+
+// Report findings
+const usersWithRatio = Object.keys(userRatios).length;
+console.log(
+  `  ${C.dim}${usersWithRatio} users with PR history, team avg ratio: ${teamAvgRatio.toFixed(1)} commits/PR${C.reset}`
+);
+
+// Show top ratios for context
+const sortedRatios = Object.entries(userRatios)
+  .sort((a, b) => a[1] - b[1])
+  .slice(0, 5);
+sortedRatios.forEach(([name, ratio]) => {
+  const display = name
+    .split(' ')
+    .map(w => w[0].toUpperCase() + w.slice(1))
+    .join(' ');
+  console.log(
+    `  ${C.dim}  ${display}: ${ratio.toFixed(1)} commits/PR${C.reset}`
+  );
+});
+
+// ─── Pass 2: Enrich with predicted PRs ──────────────────────────────────────
+
+console.log(
+  `\n${C.blue}Pass 2:${C.reset} Enriching results with predicted PRs...\n`
+);
+
+let totalPredictions = 0;
+let totalRecalculated = 0;
+let filesModified = 0;
+
+files.forEach(file => {
+  const filePath = path.join(resultsDir, file);
+  const data = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+
+  if (!data.users || !Array.isArray(data.users)) {
+    console.log(`${C.gray}  SKIP  ${file} (no users array)${C.reset}`);
+    return;
+  }
+
+  let filePredictions = 0;
+  let fileRecalculated = 0;
+
+  data.users.forEach(user => {
+    const prs = user.pullRequests || 0;
+    const commits = user.commits || 0;
+    const oldScore = user.score || 0;
+
+    if (prs === 0 && commits > 0) {
+      // No real PR data — synthesize predicted PRs
+      const ratio = userRatios[user.name] || teamAvgRatio;
+
+      if (ratio > 0) {
+        user.predictedPullRequests = parseFloat((commits / ratio).toFixed(2));
+        filePredictions++;
+      }
+    } else {
+      // Has real PR data — clear any stale prediction
+      if (user.predictedPullRequests !== undefined) {
+        delete user.predictedPullRequests;
+      }
+    }
+
+    // Recalculate score using shared scoring
+    const newScore = calculateScore(user);
+    if (Math.abs(newScore - oldScore) > 0.001) {
+      fileRecalculated++;
+    }
+    user.score = newScore;
+  });
+
+  // Re-sort by score
+  data.users.sort((a, b) => b.score - a.score);
+
+  // Recalculate team stats
+  let activeUsers = 0;
+  let teamScoreSum = 0;
+
+  data.users.forEach(user => {
+    if (user.score > 0) {
+      activeUsers++;
+      teamScoreSum += user.score;
+    }
+  });
+
+  data.activeUsers = activeUsers;
+  data.teamScore = activeUsers > 0 ? teamScoreSum / activeUsers : 0;
+
+  totalPredictions += filePredictions;
+  totalRecalculated += fileRecalculated;
+
+  const hasChanges = filePredictions > 0 || fileRecalculated > 0;
+
+  if (hasChanges) {
+    filesModified++;
+    const parts = [];
+    if (filePredictions > 0) parts.push(`${filePredictions} predicted`);
+    if (fileRecalculated > 0) parts.push(`${fileRecalculated} rescored`);
+    console.log(
+      `  ${C.green}UPDATE${C.reset}  ${file}  ${C.dim}(${parts.join(', ')})${C.reset}`
+    );
+  } else {
+    console.log(`  ${C.gray}  OK    ${file}${C.reset}`);
+  }
+
+  if (!dryRun) {
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2), 'utf8');
+  }
+});
+
+// ─── Summary ────────────────────────────────────────────────────────────────
+
+console.log(
+  `\n${C.cyan}Done.${C.reset} ${files.length} files scanned, ${filesModified} modified`
+);
+console.log(
+  `  ${C.dim}${totalPredictions} PR predictions synthesized, ${totalRecalculated} scores recalculated${C.reset}`
+);
+
+if (teamAvgRatio > 0) {
+  console.log(
+    `  ${C.dim}Team avg: ${teamAvgRatio.toFixed(1)} commits/PR (used as fallback for users with no PR history)${C.reset}\n`
+  );
+}

--- a/results-reindexer.js
+++ b/results-reindexer.js
@@ -20,6 +20,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { calculateScore } = require('./score');
 
 // ─── Terminal colors ────────────────────────────────────────────────────────
 
@@ -75,29 +76,6 @@ function getAliasForUser(user) {
 
 const ignoreUsers = (config.ignoreUsers || []).map(u => u.toLowerCase());
 
-// ─── Score calculation (mirrors gather-and-rank.js) ─────────────────────────
-
-function calculateScore(user, commitsPerPR) {
-  const loc = user.loc || 0;
-  const filesTouched = user.filesTouched || 0;
-  const pullRequests = user.pullRequests || 0;
-  const commits = user.commits || 0;
-  const reviews = user.reviews || 0;
-
-  const locScore = loc > 1000000 ? loc / 800 : loc / 100;
-  const prRatio = commitsPerPR > 0 ? (commits / commitsPerPR) * 10 : 0;
-
-  const score =
-    locScore +
-    filesTouched / 100 +
-    pullRequests * 15 +
-    commits / 100 +
-    prRatio +
-    reviews * 10;
-
-  return score || 0;
-}
-
 // ─── Process files ──────────────────────────────────────────────────────────
 
 const files = fs
@@ -137,7 +115,6 @@ files.forEach(file => {
     return;
   }
 
-  const commitsPerPR = data.commitsPerPullRequest || 0;
   let fileMerges = 0;
   let fileRenames = 0;
   let fileIgnored = 0;
@@ -180,7 +157,7 @@ files.forEach(file => {
   // Step 2: Re-calculate scores
   Object.values(merged).forEach(user => {
     delete user._seen;
-    user.score = calculateScore(user, commitsPerPR);
+    user.score = calculateScore(user);
   });
 
   // Step 3: Sort by score descending

--- a/score.js
+++ b/score.js
@@ -1,0 +1,41 @@
+/**
+ * score.js — Shared scoring weights for repo-hero.
+ *
+ * This is the single source of truth for how user scores are calculated.
+ * Used by gather-and-rank.js, results-reindexer.js, and results-enrich.js.
+ */
+
+const WEIGHTS = {
+  loc: 1 / 10000,
+  filesTouched: 1 / 10000,
+  pullRequests: 15,
+  predictedPullRequests: 15,
+  commits: 1 / 100,
+  reviews: 15,
+};
+
+/**
+ * Calculate a user's score from their metrics.
+ *
+ * Uses real pullRequests when available, otherwise falls back to
+ * predictedPullRequests (synthesized from commits-per-PR ratios).
+ *
+ * @param {{ loc?: number, filesTouched?: number, pullRequests?: number, predictedPullRequests?: number, commits?: number, reviews?: number }} user
+ * @returns {number}
+ */
+function calculateScore(user) {
+  const prs = user.pullRequests || 0;
+  const predictedPrs = user.predictedPullRequests || 0;
+  const effectivePrs = prs > 0 ? prs : predictedPrs;
+
+  const score =
+    (user.loc || 0) * WEIGHTS.loc +
+    (user.filesTouched || 0) * WEIGHTS.filesTouched +
+    effectivePrs * WEIGHTS.pullRequests +
+    (user.commits || 0) * WEIGHTS.commits +
+    (user.reviews || 0) * WEIGHTS.reviews;
+
+  return score || 0;
+}
+
+module.exports = { WEIGHTS, calculateScore };


### PR DESCRIPTION
## Summary

This PR introduces a shared scoring module, historical PR prediction enrichment, and dashboard improvements.

### Changes

#### New: `score.js` — Shared Scoring Module
- Extracts `WEIGHTS` object and `calculateScore()` function into a single shared module
- Consumed by `gather-and-rank.js`, `results-reindexer.js`, and `results-enrich.js`
- Supports `predictedPullRequests` with fallback logic (uses real PRs when available)

#### New: `results-enrich.js` — PR Prediction Enrichment
- **Pass 1**: Learns per-user commits/PR ratios from months with real PR data
- **Pass 2**: Synthesizes `predictedPullRequests` for months where a user had commits but no PR data (pre-2016 era, or projects without PR workflows)
- Falls back to team average ratio (~16.4 commits/PR) for users with no PR history
- Supports `--dry` flag for preview mode
- Integrated into `npm start` pipeline and available standalone via `npm run enrich`

#### Fix: teamScore Calculation Bug
- Previously, ignored users' scores were included in the sum before dividing by active user count
- Now correctly subtracts ignored users' scores before computing the team average

#### Updated: Dashboard (`results-dashboard.js`)
- Pull Requests metric now shows **effective PRs** (real + predicted) in charts and leaderboards
- User profiles display effective PR data in per-month breakdowns
- Added `predictedPullRequests` to the data model passed to the dashboard

#### Updated: `package.json`
- Added `npm run enrich` script
- Added `results-enrich.js` to `npm start` pipeline (runs after gather, before combine)

### Testing
- Dry run verified: 148 files scanned, 71 modified, 369 PR predictions synthesized
- Full enrichment run completed successfully
- Dashboard regenerated and verified with enriched data