### PR TITLE
Add Jira integration and Issue Resolutions metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A configurable CLI toolkit for analyzing the health of git repositories and thei
 - **Interactive dashboard** — dark, terminal-themed single-file HTML with Chart.js visualizations; no server required
 - **Flexible time scoping** — filter by 1W / 2W / 3W / 1M / 2M / 3M / 6M / 1Y / All directly in the dashboard (default: 1W)
 - **Smart overlap detection** — when weekly and monthly data coexist, the dashboard automatically prefers the more granular data
-- **Scoring engine** — configurable weighted formula across PRs, commits, reviews, completed Jira issues, LOC, and files touched (see [`score.js`](score.js))
-- **Jira issue tracking** — optionally pull completed issues from one or more Jira projects and attribute them to contributors through the same alias map used for git and GitHub identities
+- **Scoring engine** — configurable weighted formula across PRs, commits, reviews, issue resolutions, LOC, and files touched (see [`score.js`](score.js))
+- **Issue resolution tracking** — optionally pull resolved issues from one or more Jira projects and attribute them to contributors through the same alias map used for git and GitHub identities
 - **PR prediction enrichment** — for historical periods without pull requests, Repo Hero learns each user's commits-per-PR ratio and synthesizes predicted PR counts
 - **Positive outlier detection** — users performing > 1.5σ above the mean on any metric are flagged with a 🔥 badge; click the badge to see the exact z-score and explanation
 - **Repository popularity** — repos with contribution scores > 1σ above the mean are flagged with a ⭐ badge on the Repos tab
@@ -93,26 +93,26 @@ Create a `config.json` in the project root (it is gitignored). All top-level pro
 
 ### Jira Integration
 
-Jira support is entirely optional. When `jira` or `tokens.jira` is missing or incomplete,
-Repo Hero warns once and continues with GitHub-only metrics — and the dashboard hides the
-Jira metric rather than showing empty zeroes.
+Jira support is entirely optional and powers the **Issue Resolutions** metric. When `jira`
+or `tokens.jira` is missing or incomplete, Repo Hero warns once and continues with
+GitHub-only metrics — and the dashboard hides the metric rather than showing empty zeroes.
 
 **Generating an API token:** create one at
 [id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
 and pair it with the email address of the same Atlassian account.
 
-**What counts as completed:** by default, an issue counts toward a period when it sits in the
-`Done` status category and its `resolutiondate` falls inside that period's date range. Boards
-that do not follow that convention can supply their own predicate via `completedJql` — the
-project and date-range clauses are still applied on top so weekly bucketing stays correct:
+**What counts as a resolution:** by default, an issue counts toward a period when it sits in
+the `Done` status category and its `resolutiondate` falls inside that period's date range.
+Boards that do not follow that convention can supply their own predicate via `completedJql` —
+the project and date-range clauses are still applied on top so weekly bucketing stays correct:
 
 ```jsonc
 "completedJql": "status in (Shipped, Released)"
 ```
 
-**Assignee mapping:** issues are attributed to their assignee, resolved through the existing
-`aliases` map so a person's tickets roll up into the same record as their commits, PRs, and
-reviews. Resolution is attempted in this order:
+**Assignee mapping:** resolutions are attributed to the issue's assignee, resolved through the
+existing `aliases` map so a person's issues roll up into the same record as their commits,
+PRs, and reviews. Resolution is attempted in this order:
 
 1. Jira display name (e.g. `"Jane Smith"`) — matches the canonical alias keys
 2. Assignee email address, then its local part (e.g. `jsmith`) — matches alias entries
@@ -194,7 +194,7 @@ npm start
 
 ### Data Flow
 
-1. **Gather** — For each week in the date range, queries the GitHub API for pull requests, reviews, and pending commits, and runs `git log` locally for commit counts, LOC, and files touched. When Jira is configured, it also queries each configured Jira project for issues completed in the window and attributes them to their assignee. Per-user contribution breakdowns are tracked by repository (and by Jira project). Results are saved as `.results_history/YYYY-MM-DD_YYYY-MM-DD.json`. Weeks that already have result files are skipped (idempotent).
+1. **Gather** — For each week in the date range, queries the GitHub API for pull requests, reviews, and pending commits, and runs `git log` locally for commit counts, LOC, and files touched. When Jira is configured, it also queries each configured Jira project for issues resolved in the window and attributes those resolutions to their assignee. Per-user contribution breakdowns are tracked by repository (and by Jira project). Results are saved as `.results_history/YYYY-MM-DD_YYYY-MM-DD.json`. Weeks that already have result files are skipped (idempotent).
 
 2. **Enrich** — Two-pass process: first learns each user's historical commits-per-PR ratio from periods where real PR data exists, then fills in `predictedPullRequests` for periods where PRs are zero. Recalculates all user scores.
 
@@ -213,7 +213,7 @@ Scores are calculated per user per period using the weights defined in [`score.j
 | Pull Requests           | × 15     | Uses real PRs; falls back to predicted PRs if zero            |
 | Predicted Pull Requests | × 15     | Synthesized from commits-per-PR ratio (used as fallback)      |
 | Reviews                 | × 17     | Code reviews authored — weighted highest as a team multiplier |
-| Jira Issues             | × 10     | Completed Jira issues assigned to the user (when configured)  |
+| Issue Resolutions       | × 10     | Jira issues resolved by the user (when Jira is configured)    |
 | Commits                 | × 0.01   | Raw commit count                                              |
 | Lines of Code           | × 0.0001 | Net lines changed (additions + deletions)                     |
 | Files Touched           | × 0.0001 | Unique files modified                                         |
@@ -240,7 +240,7 @@ The dashboard is a self-contained HTML file with a dark, console-style theme ins
 
 ### Dashboard Tab
 
-- **Trend charts** — Score, Pull Requests, Reviews, Jira Issues (when configured), Commits, LOC, Files Touched, Active Users, Team Score
+- **Trend charts** — Score, Pull Requests, Reviews, Issue Resolutions (when configured), Commits, LOC, Files Touched, Active Users, Team Score
 - **Top 5 leaderboards** — Per metric, updated when the time scope changes
 
 ### Users Tab

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A configurable CLI toolkit for analyzing the health of git repositories and thei
 - **Interactive dashboard** — dark, terminal-themed single-file HTML with Chart.js visualizations; no server required
 - **Flexible time scoping** — filter by 1W / 2W / 3W / 1M / 2M / 3M / 6M / 1Y / All directly in the dashboard (default: 1W)
 - **Smart overlap detection** — when weekly and monthly data coexist, the dashboard automatically prefers the more granular data
-- **Scoring engine** — configurable weighted formula across PRs, commits, reviews, LOC, and files touched (see [`score.js`](score.js))
+- **Scoring engine** — configurable weighted formula across PRs, commits, reviews, completed Jira issues, LOC, and files touched (see [`score.js`](score.js))
+- **Jira issue tracking** — optionally pull completed issues from one or more Jira projects and attribute them to contributors through the same alias map used for git and GitHub identities
 - **PR prediction enrichment** — for historical periods without pull requests, Repo Hero learns each user's commits-per-PR ratio and synthesizes predicted PR counts
 - **Positive outlier detection** — users performing > 1.5σ above the mean on any metric are flagged with a 🔥 badge; click the badge to see the exact z-score and explanation
 - **Repository popularity** — repos with contribution scores > 1σ above the mean are flagged with a ⭐ badge on the Repos tab
@@ -58,6 +59,11 @@ Create a `config.json` in the project root (it is gitignored). All top-level pro
 {
   "tokens": {
     "github": "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxx", // GitHub personal access token
+    "jira": {
+      // optional — omit the whole block to disable Jira metrics
+      "email": "you@yourcompany.com", // Atlassian account email
+      "apiToken": "ATATTxxxxxxxxxxxxxxxxxxxxxxx", // Atlassian API token
+    },
   },
   "directory": "/Users/you/Development", // parent directory containing .git repos
   "startDate": "2024-01-01", // analysis start (YYYY-MM-DD)
@@ -75,8 +81,47 @@ Create a `config.json` in the project root (it is gitignored). All top-level pro
     "DevOps", // names to exclude from results
     "dependabot[bot]",
   ],
+  "jira": {
+    // optional — omit to disable Jira metrics
+    "baseUrl": "https://yourorg.atlassian.net", // Jira Cloud site URL
+    "projects": ["ENG", "OPS"], // project keys to pull completed issues from
+    "completedJql": null, // optional override for the "completed" definition
+    "excludeIssueTypes": ["Epic"], // optional issue types to skip
+  },
 }
 ```
+
+### Jira Integration
+
+Jira support is entirely optional. When `jira` or `tokens.jira` is missing or incomplete,
+Repo Hero warns once and continues with GitHub-only metrics — and the dashboard hides the
+Jira metric rather than showing empty zeroes.
+
+**Generating an API token:** create one at
+[id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
+and pair it with the email address of the same Atlassian account.
+
+**What counts as completed:** by default, an issue counts toward a period when it sits in the
+`Done` status category and its `resolutiondate` falls inside that period's date range. Boards
+that do not follow that convention can supply their own predicate via `completedJql` — the
+project and date-range clauses are still applied on top so weekly bucketing stays correct:
+
+```jsonc
+"completedJql": "status in (Shipped, Released)"
+```
+
+**Assignee mapping:** issues are attributed to their assignee, resolved through the existing
+`aliases` map so a person's tickets roll up into the same record as their commits, PRs, and
+reviews. Resolution is attempted in this order:
+
+1. Jira display name (e.g. `"Jane Smith"`) — matches the canonical alias keys
+2. Assignee email address, then its local part (e.g. `jsmith`) — matches alias entries
+3. Atlassian account ID — last resort so the issue is still counted
+
+Most Jira Cloud sites hide email addresses for privacy, so the **display name is usually the
+value that has to match**. If a teammate's Jira display name differs from their canonical
+alias key, add it to their `aliases` array. Unassigned issues are skipped and reported in the
+run summary.
 
 ### Quick Reconfigure
 
@@ -149,7 +194,7 @@ npm start
 
 ### Data Flow
 
-1. **Gather** — For each week in the date range, queries the GitHub API for pull requests, reviews, and pending commits, and runs `git log` locally for commit counts, LOC, and files touched. Per-user contribution breakdowns are tracked by repository. Results are saved as `.results_history/YYYY-MM-DD_YYYY-MM-DD.json`. Weeks that already have result files are skipped (idempotent).
+1. **Gather** — For each week in the date range, queries the GitHub API for pull requests, reviews, and pending commits, and runs `git log` locally for commit counts, LOC, and files touched. When Jira is configured, it also queries each configured Jira project for issues completed in the window and attributes them to their assignee. Per-user contribution breakdowns are tracked by repository (and by Jira project). Results are saved as `.results_history/YYYY-MM-DD_YYYY-MM-DD.json`. Weeks that already have result files are skipped (idempotent).
 
 2. **Enrich** — Two-pass process: first learns each user's historical commits-per-PR ratio from periods where real PR data exists, then fills in `predictedPullRequests` for periods where PRs are zero. Recalculates all user scores.
 
@@ -168,6 +213,7 @@ Scores are calculated per user per period using the weights defined in [`score.j
 | Pull Requests           | × 15     | Uses real PRs; falls back to predicted PRs if zero            |
 | Predicted Pull Requests | × 15     | Synthesized from commits-per-PR ratio (used as fallback)      |
 | Reviews                 | × 17     | Code reviews authored — weighted highest as a team multiplier |
+| Jira Issues             | × 10     | Completed Jira issues assigned to the user (when configured)  |
 | Commits                 | × 0.01   | Raw commit count                                              |
 | Lines of Code           | × 0.0001 | Net lines changed (additions + deletions)                     |
 | Files Touched           | × 0.0001 | Unique files modified                                         |
@@ -194,7 +240,7 @@ The dashboard is a self-contained HTML file with a dark, console-style theme ins
 
 ### Dashboard Tab
 
-- **Trend charts** — Score, Pull Requests, Reviews, Commits, LOC, Files Touched, Active Users, Team Score
+- **Trend charts** — Score, Pull Requests, Reviews, Jira Issues (when configured), Commits, LOC, Files Touched, Active Users, Team Score
 - **Top 5 leaderboards** — Per metric, updated when the time scope changes
 
 ### Users Tab

--- a/gather-and-rank.js
+++ b/gather-and-rank.js
@@ -43,6 +43,8 @@ let _ALIASES = {}; // { key: [value: string[]] }
 let _RESULTS = {}; // any (results_timestamp.json)
 let _GITHUB_API = null; // axios instance for the GitHub API
 let _GITHUB_SEARCH_API = null; // axios instance for the GitHub API
+let _JIRA_API = null; // axios instance for the Jira Cloud API
+let _JIRA_ENABLED = false; // whether the Jira pass should run for this session
 let _CACHE = null; // any (cache.json)
 
 // ----- helper functions -----
@@ -140,6 +142,56 @@ function getAliasForUser(user) {
 }
 
 /**
+ * Resolve a Jira assignee object down to the same normalized alias that the
+ * git/GitHub side of the pipeline uses, so a person's tickets land on the same
+ * user record as their commits, pull requests, and reviews.
+ *
+ * Jira exposes a display name, and (depending on the account's GDPR privacy
+ * settings) possibly an email address. Resolution is attempted in order of how
+ * likely each value is to already appear in the configured aliases:
+ *
+ *   1. displayName        — matches the canonical alias keys, e.g. "Jane Smith"
+ *   2. emailAddress       — matches alias entries written as full addresses
+ *   3. email local part   — matches alias entries written as usernames/logins
+ *   4. accountId          — stable last resort so the issue is still counted
+ *
+ * @param {{ displayName?: string, emailAddress?: string, accountId?: string }} assignee
+ * @returns {string | null} The normalized alias, or null when unassigned.
+ */
+function getAliasForJiraUser(assignee) {
+  if (!assignee) {
+    return null;
+  }
+
+  const candidates = [];
+
+  if (assignee.displayName) {
+    candidates.push(assignee.displayName);
+  }
+
+  if (assignee.emailAddress) {
+    candidates.push(assignee.emailAddress);
+    candidates.push(assignee.emailAddress.split('@')[0]);
+  }
+
+  // Prefer a candidate that is explicitly mapped by the configured aliases
+  for (const candidate of candidates) {
+    const normalized = removeEmailAccount(candidate.toLowerCase()).trim();
+
+    if (_ALIASES[normalized]) {
+      return _ALIASES[normalized].toLowerCase().trim();
+    }
+  }
+
+  // Otherwise fall back to the display name, which matches canonical alias keys
+  if (candidates.length > 0) {
+    return getAliasForUser(candidates[0]);
+  }
+
+  return assignee.accountId ? assignee.accountId.toLowerCase().trim() : null;
+}
+
+/**
  * Executes a shell command and returns a promise that resolves with the response.
  *
  * @param {string} command The command to execute.
@@ -163,6 +215,70 @@ async function executeCommand(command, directory) {
 }
 
 /**
+ * Lazily populate the in-memory response cache from the on-disk cache files.
+ *
+ * Shared by every API layer (GitHub and Jira) so that whichever one issues the
+ * first request pays the load cost and the rest reuse the same map.
+ */
+function _loadCache() {
+  const cacheDir = path.join(__dirname, '.results_cache');
+
+  if (!_CACHE && _CONFIG?.skipCache) {
+    console.log(`\n${_cFgYellow}Cache reading disabled. ${_cReset}\n`);
+  }
+
+  if (_CACHE) {
+    return;
+  }
+
+  _CACHE = {};
+
+  // If the skip cache flag is enabled, don't bother reading in cache files
+  if (_CONFIG?.skipCache) {
+    return;
+  }
+
+  console.log(
+    `\n${_cFgYellow}Populating results cache. This might take a while...${_cReset}\n`
+  );
+
+  try {
+    const files = fs.readdirSync(cacheDir);
+    // Sort alphabetically so that cache_{timestamp}_... files are read in
+    // chronological order — the last entry for any given key wins.
+    const jsonFiles = files
+      .filter(file => path.extname(file) === '.json')
+      .sort();
+
+    if (jsonFiles.length > 0) {
+      jsonFiles.forEach(file => {
+        try {
+          const filePath = path.join(cacheDir, file);
+          const fileContent = fs.readFileSync(filePath, 'utf8');
+
+          const data = JSON.parse(fileContent);
+          // Extract write timestamp from filename: cache_{timestamp}_{uuid}.json
+          const fileTs = parseInt(file.split('_')[1], 10) || 0;
+          Object.keys(data).forEach(dataKey => {
+            // Preserve any _written_at already stored in the value, or
+            // fall back to the timestamp embedded in the filename.
+            _CACHE[dataKey] = {
+              ...data[dataKey],
+              _written_at: data[dataKey]._written_at ?? fileTs,
+            };
+          });
+        } catch (cacheError) {
+          `  ${_cFgGray}Error parsing a cache file. Consider removal of ${path.join(cacheDir, file)}${_cReset}`;
+        }
+      });
+    }
+  } catch (error) {
+    console.error('An error occurred while processing cache files:', error);
+    _CACHE = {};
+  }
+}
+
+/**
  *
  * @param {string} req The path of the endpoint to fetch data from.
  * @param {any} options The request options.
@@ -176,55 +292,7 @@ async function getFromGitHubAPI(req, options) {
     key += `--qps--${JSON.stringify(options)}`;
   }
 
-  if (!_CACHE && _CONFIG?.skipCache) {
-    console.log(`\n${_cFgYellow}Cache reading disabled. ${_cReset}\n`);
-  }
-
-  if (!_CACHE) {
-    _CACHE = {};
-
-    // If the skip cache flag is enabled, don't bother reading in cache files
-    if (!_CONFIG?.skipCache) {
-      console.log(
-        `\n${_cFgYellow}Populating results cache. This might take a while...${_cReset}\n`
-      );
-
-      try {
-        const files = fs.readdirSync(cacheDir);
-        // Sort alphabetically so that cache_{timestamp}_... files are read in
-        // chronological order — the last entry for any given key wins.
-        const jsonFiles = files
-          .filter(file => path.extname(file) === '.json')
-          .sort();
-
-        if (jsonFiles.length > 0) {
-          jsonFiles.forEach(file => {
-            try {
-              const filePath = path.join(cacheDir, file);
-              const fileContent = fs.readFileSync(filePath, 'utf8');
-
-              const data = JSON.parse(fileContent);
-              // Extract write timestamp from filename: cache_{timestamp}_{uuid}.json
-              const fileTs = parseInt(file.split('_')[1], 10) || 0;
-              Object.keys(data).forEach(dataKey => {
-                // Preserve any _written_at already stored in the value, or
-                // fall back to the timestamp embedded in the filename.
-                _CACHE[dataKey] = {
-                  ...data[dataKey],
-                  _written_at: data[dataKey]._written_at ?? fileTs,
-                };
-              });
-            } catch (cacheError) {
-              `  ${_cFgGray}Error parsing a cache file. Consider removal of ${path.join(cacheDir, file)}${_cReset}`;
-            }
-          });
-        }
-      } catch (error) {
-        console.error('An error occurred while processing cache files:', error);
-        _CACHE = {};
-      }
-    }
-  }
+  _loadCache();
 
   if (!_CONFIG?.skipCache && _CACHE[key]) {
     // Staleness check: for GitHub search queries with a `created:START..END` date
@@ -306,6 +374,167 @@ async function getFromGitHubAPI(req, options) {
   } catch (error) {
     throw error;
   }
+}
+
+/**
+ * Perform a GET against the Jira Cloud REST API, transparently reading from and
+ * writing to the same on-disk response cache used for GitHub requests.
+ *
+ * Cache keys are prefixed with `jira:` so they never collide with GitHub paths,
+ * and entries are considered stale when they were written before the end of the
+ * resolution window they describe. That mirrors the GitHub `created:` staleness
+ * check and prevents an empty result — cached while the week was still in the
+ * future — from being reused forever.
+ *
+ * @param {string} req The Jira API path, e.g. '/rest/api/3/search/jql'.
+ * @param {object} [options] Axios request options (params, etc).
+ * @returns {Promise<any>} The axios response (or the cached equivalent).
+ */
+async function getFromJiraAPI(req, options) {
+  const cacheDir = path.join(__dirname, '.results_cache');
+
+  let key = `jira:${req}`;
+  if (options) {
+    key += `--qps--${JSON.stringify(options)}`;
+  }
+
+  _loadCache();
+
+  if (!_CONFIG?.skipCache && _CACHE[key]) {
+    // Staleness check: JQL queries carry a `resolutiondate <= "END"` bound. If
+    // the entry was cached before that window closed, the data is incomplete.
+    const rangeMatch = key.match(/resolutiondate <= \\"(\d{4}-\d{2}-\d{2})/);
+
+    if (rangeMatch) {
+      const searchEndMs = new Date(rangeMatch[1] + 'T23:59:59Z').getTime();
+
+      if ((_CACHE[key]._written_at ?? 0) < searchEndMs) {
+        delete _CACHE[key]; // stale — fall through to make a fresh API call
+      }
+    }
+  }
+
+  if (!_CONFIG?.skipCache && _CACHE[key]) {
+    const { _written_at, ...cacheVal } = _CACHE[key];
+
+    console.log(
+      `Re-using cached data from Jira API: ${_cFgYellow}${req}${_cReset}`
+    );
+
+    return cacheVal;
+  }
+
+  console.log(`Fetching data from Jira API: ${_cFgBlue}${req}${_cReset}`);
+
+  const response = await _JIRA_API.get(req, options);
+
+  if (response?.status !== 200) {
+    return response;
+  }
+
+  _CACHE[key] = {
+    data: response.data,
+    headers: response.headers,
+    _written_at: Date.now(),
+  };
+
+  const filename = `cache_${Date.now()}_${uuidv4()}.json`;
+
+  const saveData = {};
+  saveData[key] = _CACHE[key];
+
+  // Check if the .results_cache folder exists, if not, create it
+  if (!fs.existsSync(cacheDir)) {
+    fs.mkdirSync(cacheDir);
+  }
+
+  console.log(
+    `  ${_cFgGray}Cached at: ./results_cache/${filename}${_cReset}\n`
+  );
+
+  fs.writeFile(
+    path.join(cacheDir, filename),
+    JSON.stringify(saveData, null, 2),
+    () => {}
+  );
+
+  return response;
+}
+
+/**
+ * Build the JQL used to find issues completed inside the reporting window for a
+ * single Jira project.
+ *
+ * By default an issue counts as completed when it carries a resolution date
+ * inside the window and currently sits in the "Done" status category. Teams
+ * whose boards do not follow that convention can supply `jira.completedJql` in
+ * the configuration; the project and date clauses are still applied so that
+ * weekly bucketing stays correct.
+ *
+ * @param {string} projectKey The Jira project key, e.g. 'ENG'.
+ * @returns {string} The JQL query string.
+ */
+function buildCompletedIssuesJql(projectKey) {
+  const clauses = [`project = "${projectKey}"`];
+
+  if (_CONFIG?.jira?.completedJql) {
+    clauses.push(`(${_CONFIG.jira.completedJql})`);
+  } else {
+    clauses.push('statusCategory = Done');
+  }
+
+  clauses.push(`resolutiondate >= "${_START_DATE}"`);
+  clauses.push(`resolutiondate <= "${_END_DATE} 23:59"`);
+
+  const excluded = _CONFIG?.jira?.excludeIssueTypes;
+  if (Array.isArray(excluded) && excluded.length > 0) {
+    clauses.push(
+      `issuetype not in (${excluded.map(t => `"${t}"`).join(', ')})`
+    );
+  }
+
+  return clauses.join(' AND ');
+}
+
+/**
+ * Fetch every issue completed within the reporting window for a Jira project.
+ *
+ * Uses the `/rest/api/3/search/jql` endpoint, which paginates with an opaque
+ * `nextPageToken` rather than `startAt` and returns no total count, so pages are
+ * walked until no further token is returned.
+ *
+ * @param {string} projectKey The Jira project key, e.g. 'ENG'.
+ * @returns {Promise<any[]>} All matching issues.
+ */
+async function fetchCompletedJiraIssues(projectKey) {
+  const jql = buildCompletedIssuesJql(projectKey);
+  const issues = [];
+
+  let nextPageToken = null;
+  let hasMorePages = true;
+
+  while (hasMorePages) {
+    const params = {
+      jql,
+      maxResults: 100,
+      fields: 'assignee,resolutiondate,issuetype,summary',
+    };
+
+    if (nextPageToken) {
+      params.nextPageToken = nextPageToken;
+    }
+
+    const response = await getFromJiraAPI('/rest/api/3/search/jql', { params });
+
+    if (Array.isArray(response?.data?.issues)) {
+      issues.push(...response.data.issues);
+    }
+
+    nextPageToken = response?.data?.nextPageToken || null;
+    hasMorePages = !!nextPageToken && !response?.data?.isLast;
+  }
+
+  return issues;
 }
 
 /**
@@ -682,6 +911,122 @@ function _configureApp() {
       'GitHub API token not configured. Consider adding config.json .tokens.github for more stats!'
     );
   }
+
+  _configureJira();
+}
+
+/**
+ * Configure the optional Jira integration.
+ *
+ * The integration is entirely opt-in: when `jira` or `tokens.jira` is missing or
+ * incomplete we warn and continue so that a configuration without Jira behaves
+ * exactly as it did before the integration existed.
+ */
+function _configureJira() {
+  const jira = _CONFIG?.jira;
+  const credentials = _CONFIG?.tokens?.jira;
+
+  if (!jira && !credentials) {
+    // Jira is simply not in use for this configuration — stay quiet.
+    return;
+  }
+
+  if (!jira?.baseUrl) {
+    console.warn(
+      `${_cFgYellow}Jira is partially configured: missing jira.baseUrl. Skipping Jira issue metrics.${_cReset}`
+    );
+    return;
+  }
+
+  if (!Array.isArray(jira.projects) || jira.projects.length === 0) {
+    console.warn(
+      `${_cFgYellow}Jira is partially configured: jira.projects must be a non-empty array of project keys. Skipping Jira issue metrics.${_cReset}`
+    );
+    return;
+  }
+
+  if (!credentials?.email || !credentials?.apiToken) {
+    console.warn(
+      `${_cFgYellow}Jira is partially configured: missing tokens.jira.email or tokens.jira.apiToken. Skipping Jira issue metrics.${_cReset}`
+    );
+    return;
+  }
+
+  let baseURL;
+  try {
+    baseURL = new URL(jira.baseUrl).origin;
+  } catch {
+    console.warn(
+      `${_cFgYellow}Invalid jira.baseUrl "${jira.baseUrl}". Skipping Jira issue metrics.${_cReset}`
+    );
+    return;
+  }
+
+  const auth = Buffer.from(
+    `${credentials.email}:${credentials.apiToken}`
+  ).toString('base64');
+
+  _JIRA_API = rateLimit(
+    axios.create({
+      baseURL,
+      headers: {
+        Authorization: `Basic ${auth}`,
+        Accept: 'application/json',
+      },
+    }),
+    {
+      // Jira Cloud allows roughly 10 requests/second per user; stay conservative
+      // and match the pacing already used for the GitHub core API.
+      maxRequests: 5,
+      perMilliseconds: 2000,
+    }
+  );
+
+  _JIRA_ENABLED = true;
+}
+
+/**
+ * Validates the configured Jira credentials by calling /rest/api/3/myself.
+ *
+ * A failure here disables the Jira pass for the run rather than aborting the
+ * whole gather, so a stale Atlassian token never costs you your GitHub data.
+ *
+ * @returns {Promise<void>}
+ */
+async function _validateJiraToken() {
+  if (!_JIRA_ENABLED) {
+    return;
+  }
+
+  try {
+    const response = await _JIRA_API.get('/rest/api/3/myself');
+    console.log(
+      `\n${_cFgBlue}Jira API${_cReset} authenticated as ${response?.data?.displayName || 'unknown user'}.\n`
+    );
+  } catch (error) {
+    const status = error?.response?.status;
+
+    if (status === 401 || status === 403) {
+      console.error(
+        `\n${_cFgRed}✗ Jira credentials are invalid or expired.${_cReset}`
+      );
+      console.error(
+        `  Update ${_cFgYellow}tokens.jira.email${_cReset} and ${_cFgYellow}tokens.jira.apiToken${_cReset} in config.json.`
+      );
+      console.error(
+        `  Generate a token at: https://id.atlassian.com/manage-profile/security/api-tokens`
+      );
+    } else {
+      console.warn(
+        `\n${_cFgYellow}Warning: could not reach Jira to validate credentials.${_cReset}`
+      );
+    }
+
+    console.warn(
+      `${_cFgYellow}Continuing without Jira issue metrics.${_cReset}\n`
+    );
+    _JIRA_ENABLED = false;
+  }
 }
 
 /**
@@ -1048,6 +1393,91 @@ function _processProjects() {
   });
 }
 
+/**
+ * Fetch and tally the Jira issues completed within the reporting window across
+ * every configured Jira project.
+ *
+ * Each issue is attributed to its assignee, normalized through the same alias
+ * map used for git authors and GitHub logins, so a person's tickets roll up into
+ * the same user record as the rest of their contributions.
+ *
+ * @returns {Promise<void>}
+ */
+async function _processJiraProjects() {
+  if (!_JIRA_ENABLED) {
+    return;
+  }
+
+  const projects = _CONFIG.jira.projects;
+
+  console.log(
+    `Fetching completed issues from ${projects.length} Jira projects...`
+  );
+
+  if (!_RESULTS.users) {
+    _RESULTS.users = {};
+  }
+
+  if (!_RESULTS.totalJiraIssues) {
+    _RESULTS.totalJiraIssues = 0;
+  }
+
+  let unassigned = 0;
+
+  for (const projectKey of projects) {
+    let issues = [];
+
+    try {
+      issues = await fetchCompletedJiraIssues(projectKey);
+    } catch (error) {
+      console.error(
+        `Error fetching Jira issues for project ${projectKey}:`,
+        error?.response?.data?.errorMessages || error.message
+      );
+      continue;
+    }
+
+    issues.forEach(issue => {
+      const alias = getAliasForJiraUser(issue?.fields?.assignee);
+
+      if (!alias) {
+        unassigned++;
+        return;
+      }
+
+      if (!_RESULTS.users[alias]) {
+        _RESULTS.users[alias] = {};
+      }
+
+      if (!_RESULTS.users[alias].jiraIssues) {
+        _RESULTS.users[alias].jiraIssues = 0;
+      }
+
+      if (!_RESULTS.users[alias].jiraBreakdown) {
+        _RESULTS.users[alias].jiraBreakdown = {};
+      }
+
+      if (!_RESULTS.users[alias].jiraBreakdown[projectKey]) {
+        _RESULTS.users[alias].jiraBreakdown[projectKey] = 0;
+      }
+
+      _RESULTS.users[alias].jiraIssues++;
+      _RESULTS.users[alias].jiraBreakdown[projectKey]++;
+      _RESULTS.totalJiraIssues++;
+    });
+
+    console.log(
+      `  ${_cFgGray}${projectKey}: ${issues.length} completed issues${_cReset}`
+    );
+  }
+
+  if (unassigned > 0) {
+    console.log(
+      `  ${_cFgYellow}${unassigned} completed issues had no assignee and were not attributed.${_cReset}`
+    );
+  }
+}
+
 function processUserCommits(packageName, project) {
   return new Promise((resolve, reject) => {
     executeCommand(
@@ -1127,7 +1557,14 @@ _configureApp();
 // If the token is invalid, process.exit(1) fires before .finally() so no
 // partial result file is written and no existing files are overwritten.
 _validateToken()
+  .then(() => _validateJiraToken())
   .then(() => _processProjects())
+  .then(() =>
+    _processJiraProjects().catch(error => {
+      // Never let a Jira failure discard an otherwise successful GitHub gather.
+      console.error('Error processing Jira projects:', error.message);
+    })
+  )
   .catch(() => {
     process.exit(1);
   })
@@ -1146,6 +1583,10 @@ _validateToken()
         : _RESULTS.totalCommits / _RESULTS.commitsPerPullRequest;
     _RESULTS.activeUsers = 0;
     _RESULTS.teamScore = 0;
+
+    if (!_RESULTS.totalJiraIssues) {
+      _RESULTS.totalJiraIssues = 0;
+    }
 
     // assess the results for all users
     if (!!_RESULTS?.users) {
@@ -1166,6 +1607,11 @@ _validateToken()
         // make sure loc is defined
         if (!_RESULTS.users[user].loc) {
           _RESULTS.users[user].loc = 0;
+        }
+
+        // make sure completed jira issues are defined
+        if (!_RESULTS.users[user].jiraIssues) {
+          _RESULTS.users[user].jiraIssues = 0;
         }
 
         // calculate the user score

--- a/gather-and-rank.js
+++ b/gather-and-rank.js
@@ -933,21 +933,21 @@ function _configureJira() {
 
   if (!jira?.baseUrl) {
     console.warn(
-      `${_cFgYellow}Jira is partially configured: missing jira.baseUrl. Skipping Jira issue metrics.${_cReset}`
+      `${_cFgYellow}Jira is partially configured: missing jira.baseUrl. Skipping issue resolution metrics.${_cReset}`
     );
     return;
   }
 
   if (!Array.isArray(jira.projects) || jira.projects.length === 0) {
     console.warn(
-      `${_cFgYellow}Jira is partially configured: jira.projects must be a non-empty array of project keys. Skipping Jira issue metrics.${_cReset}`
+      `${_cFgYellow}Jira is partially configured: jira.projects must be a non-empty array of project keys. Skipping issue resolution metrics.${_cReset}`
     );
     return;
   }
 
   if (!credentials?.email || !credentials?.apiToken) {
     console.warn(
-      `${_cFgYellow}Jira is partially configured: missing tokens.jira.email or tokens.jira.apiToken. Skipping Jira issue metrics.${_cReset}`
+      `${_cFgYellow}Jira is partially configured: missing tokens.jira.email or tokens.jira.apiToken. Skipping issue resolution metrics.${_cReset}`
     );
     return;
   }
@@ -957,7 +957,7 @@ function _configureJira() {
     baseURL = new URL(jira.baseUrl).origin;
   } catch {
     console.warn(
-      `${_cFgYellow}Invalid jira.baseUrl "${jira.baseUrl}". Skipping Jira issue metrics.${_cReset}`
+      `${_cFgYellow}Invalid jira.baseUrl "${jira.baseUrl}". Skipping issue resolution metrics.${_cReset}`
     );
     return;
   }
@@ -1023,7 +1023,7 @@ async function _validateJiraToken() {
     }
 
     console.warn(
-      `${_cFgYellow}Continuing without Jira issue metrics.${_cReset}\n`
+      `${_cFgYellow}Continuing without issue resolution metrics.${_cReset}\n`
     );
     _JIRA_ENABLED = false;
   }
@@ -1394,8 +1394,8 @@ function _processProjects() {
 }
 
 /**
- * Fetch and tally the Jira issues completed within the reporting window across
- * every configured Jira project.
+ * Fetch and tally the issue resolutions recorded within the reporting window
+ * across every configured Jira project.
  *
  * Each issue is attributed to its assignee, normalized through the same alias
  * map used for git authors and GitHub logins, so a person's tickets roll up into
@@ -1411,15 +1411,15 @@ async function _processJiraProjects() {
   const projects = _CONFIG.jira.projects;
 
   console.log(
-    `Fetching completed issues from ${projects.length} Jira projects...`
+    `Fetching issue resolutions from ${projects.length} Jira projects...`
   );
 
   if (!_RESULTS.users) {
     _RESULTS.users = {};
   }
 
-  if (!_RESULTS.totalJiraIssues) {
-    _RESULTS.totalJiraIssues = 0;
+  if (!_RESULTS.totalIssueResolutions) {
+    _RESULTS.totalIssueResolutions = 0;
   }
 
   let unassigned = 0;
@@ -1449,31 +1449,31 @@ async function _processJiraProjects() {
         _RESULTS.users[alias] = {};
       }
 
-      if (!_RESULTS.users[alias].jiraIssues) {
-        _RESULTS.users[alias].jiraIssues = 0;
+      if (!_RESULTS.users[alias].issueResolutions) {
+        _RESULTS.users[alias].issueResolutions = 0;
       }
 
-      if (!_RESULTS.users[alias].jiraBreakdown) {
-        _RESULTS.users[alias].jiraBreakdown = {};
+      if (!_RESULTS.users[alias].resolutionBreakdown) {
+        _RESULTS.users[alias].resolutionBreakdown = {};
       }
 
-      if (!_RESULTS.users[alias].jiraBreakdown[projectKey]) {
-        _RESULTS.users[alias].jiraBreakdown[projectKey] = 0;
+      if (!_RESULTS.users[alias].resolutionBreakdown[projectKey]) {
+        _RESULTS.users[alias].resolutionBreakdown[projectKey] = 0;
       }
 
-      _RESULTS.users[alias].jiraIssues++;
-      _RESULTS.users[alias].jiraBreakdown[projectKey]++;
-      _RESULTS.totalJiraIssues++;
+      _RESULTS.users[alias].issueResolutions++;
+      _RESULTS.users[alias].resolutionBreakdown[projectKey]++;
+      _RESULTS.totalIssueResolutions++;
     });
 
     console.log(
-      `  ${_cFgGray}${projectKey}: ${issues.length} completed issues${_cReset}`
+      `  ${_cFgGray}${projectKey}: ${issues.length} issue resolutions${_cReset}`
     );
   }
 
   if (unassigned > 0) {
     console.log(
-      `  ${_cFgYellow}${unassigned} completed issues had no assignee and were not attributed.${_cReset}`
+      `  ${_cFgYellow}${unassigned} resolved issues had no assignee and were not attributed.${_cReset}`
     );
   }
 }
@@ -1584,8 +1584,8 @@ _validateToken()
     _RESULTS.activeUsers = 0;
     _RESULTS.teamScore = 0;
 
-    if (!_RESULTS.totalJiraIssues) {
-      _RESULTS.totalJiraIssues = 0;
+    if (!_RESULTS.totalIssueResolutions) {
+      _RESULTS.totalIssueResolutions = 0;
     }
 
     // assess the results for all users
@@ -1610,8 +1610,8 @@ _validateToken()
         }
 
         // make sure completed jira issues are defined
-        if (!_RESULTS.users[user].jiraIssues) {
-          _RESULTS.users[user].jiraIssues = 0;
+        if (!_RESULTS.users[user].issueResolutions) {
+          _RESULTS.users[user].issueResolutions = 0;
         }
 
         // calculate the user score

--- a/help.js
+++ b/help.js
@@ -36,7 +36,7 @@ console.log(
   `    ${_cFgGreen}gather${_cReset}\t(gather data and generate .results_history/*.json)`
 );
 console.log(
-  `    \t\t  (includes completed Jira issues when config.json .jira is set)`
+  `    \t\t  (includes issue resolutions when config.json .jira is set)`
 );
 console.log(`    \t\t  --start YYYY-MM-DD  (override start date)`);
 console.log(`    \t\t  --end   YYYY-MM-DD  (override end date)`);

--- a/help.js
+++ b/help.js
@@ -35,6 +35,9 @@ console.log(`  ${_cFgGreen}start${_cReset}\t\t(execute all)`);
 console.log(
   `    ${_cFgGreen}gather${_cReset}\t(gather data and generate .results_history/*.json)`
 );
+console.log(
+  `    \t\t  (includes completed Jira issues when config.json .jira is set)`
+);
 console.log(`    \t\t  --start YYYY-MM-DD  (override start date)`);
 console.log(`    \t\t  --end   YYYY-MM-DD  (override end date)`);
 console.log(

--- a/results-cache-cleanup.js
+++ b/results-cache-cleanup.js
@@ -277,12 +277,23 @@ if (!fs.existsSync(cacheDir)) {
         const content = fs.readFileSync(path.join(cacheDir, file), 'utf8');
         const data = JSON.parse(content);
         Object.keys(data).forEach(apiKey => {
-          if (!apiKey.includes('created:')) return;
+          // GitHub search windows use `created:START..END`; Jira JQL windows
+          // use `resolutiondate <= "END"`. Both can capture a future, empty
+          // period and both need the same staleness treatment.
+          if (
+            !apiKey.includes('created:') &&
+            !apiKey.includes('resolutiondate <=')
+          ) {
+            return;
+          }
           if (!searchKeyLatest[apiKey] || ts > searchKeyLatest[apiKey].ts) {
             searchKeyLatest[apiKey] = {
               file,
               ts,
-              items: data[apiKey]?.data?.items?.length ?? null,
+              items:
+                data[apiKey]?.data?.items?.length ??
+                data[apiKey]?.data?.issues?.length ??
+                null,
             };
           }
         });
@@ -294,11 +305,12 @@ if (!fs.existsSync(cacheDir)) {
     const staleFiles = new Set();
 
     Object.entries(searchKeyLatest).forEach(([apiKey, { file, ts, items }]) => {
-      const rangeMatch = apiKey.match(
-        /created:(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})/
-      );
+      const rangeMatch =
+        apiKey.match(/created:(\d{4}-\d{2}-\d{2})\.\.(\d{4}-\d{2}-\d{2})/) ||
+        apiKey.match(/resolutiondate <= \\"(\d{4}-\d{2}-\d{2})/);
       if (!rangeMatch) return;
-      const searchEndMs = new Date(rangeMatch[2] + 'T23:59:59Z').getTime();
+      const windowEnd = rangeMatch[2] || rangeMatch[1];
+      const searchEndMs = new Date(windowEnd + 'T23:59:59Z').getTime();
       if (ts < searchEndMs) {
         staleFiles.add(file);
       }

--- a/results-charter.js
+++ b/results-charter.js
@@ -17,6 +17,7 @@ const trendingPullRequests = {};
 const trendingFilesTouched = {};
 const trendingReviews = {};
 const trendingLoc = {};
+const trendingJiraIssues = {};
 
 // Loop through JSON data
 for (const [key, value] of Object.entries(data)) {
@@ -33,6 +34,7 @@ for (const [key, value] of Object.entries(data)) {
         trendingFilesTouched[name] = {};
         trendingReviews[name] = {};
         trendingLoc[name] = {};
+        trendingJiraIssues[name] = {};
       }
 
       trendingScore[name][date] = user.score || 0;
@@ -41,6 +43,7 @@ for (const [key, value] of Object.entries(data)) {
       trendingFilesTouched[name][date] = user.filesTouched || 0;
       trendingReviews[name][date] = user.reviews || 0;
       trendingLoc[name][date] = user.loc || 0;
+      trendingJiraIssues[name][date] = user.jiraIssues || 0;
     }
   }
 }
@@ -72,6 +75,7 @@ const outputFiles = [
   'trending_filesTouched.csv',
   'trending_reviews.csv',
   'trending_loc.csv',
+  'trending_jiraIssues.csv',
 ];
 
 outputFiles.forEach(outputFilePath => {
@@ -87,3 +91,4 @@ writeCsv('trending_pullRequests.csv', trendingPullRequests);
 writeCsv('trending_filesTouched.csv', trendingFilesTouched);
 writeCsv('trending_reviews.csv', trendingReviews);
 writeCsv('trending_loc.csv', trendingLoc);
+writeCsv('trending_jiraIssues.csv', trendingJiraIssues);

--- a/results-charter.js
+++ b/results-charter.js
@@ -17,7 +17,7 @@ const trendingPullRequests = {};
 const trendingFilesTouched = {};
 const trendingReviews = {};
 const trendingLoc = {};
-const trendingJiraIssues = {};
+const trendingIssueResolutions = {};
 
 // Loop through JSON data
 for (const [key, value] of Object.entries(data)) {
@@ -34,7 +34,7 @@ for (const [key, value] of Object.entries(data)) {
         trendingFilesTouched[name] = {};
         trendingReviews[name] = {};
         trendingLoc[name] = {};
-        trendingJiraIssues[name] = {};
+        trendingIssueResolutions[name] = {};
       }
 
       trendingScore[name][date] = user.score || 0;
@@ -43,7 +43,7 @@ for (const [key, value] of Object.entries(data)) {
       trendingFilesTouched[name][date] = user.filesTouched || 0;
       trendingReviews[name][date] = user.reviews || 0;
       trendingLoc[name][date] = user.loc || 0;
-      trendingJiraIssues[name][date] = user.jiraIssues || 0;
+      trendingIssueResolutions[name][date] = user.issueResolutions || 0;
     }
   }
 }
@@ -75,7 +75,7 @@ const outputFiles = [
   'trending_filesTouched.csv',
   'trending_reviews.csv',
   'trending_loc.csv',
-  'trending_jiraIssues.csv',
+  'trending_issueResolutions.csv',
 ];
 
 outputFiles.forEach(outputFilePath => {
@@ -91,4 +91,4 @@ writeCsv('trending_pullRequests.csv', trendingPullRequests);
 writeCsv('trending_filesTouched.csv', trendingFilesTouched);
 writeCsv('trending_reviews.csv', trendingReviews);
 writeCsv('trending_loc.csv', trendingLoc);
-writeCsv('trending_jiraIssues.csv', trendingJiraIssues);
+writeCsv('trending_issueResolutions.csv', trendingIssueResolutions);

--- a/results-dashboard.js
+++ b/results-dashboard.js
@@ -28,9 +28,9 @@ const dashboardData = {
   periods: [],
   users: {},
   team: [],
-  // Jira is an opt-in integration. When no results file carries Jira data the
-  // dashboard hides the metric entirely rather than showing empty zeroes.
-  hasJira: false,
+  // Jira is an opt-in integration. When no results file carries resolution data
+  // the dashboard hides the metric entirely rather than showing empty zeroes.
+  hasIssueResolutions: false,
 };
 
 // First pass: collect all periods with their date ranges
@@ -153,11 +153,11 @@ filteredEntries.forEach(({ entry, startDate, endDate }) => {
       pullRequests: user.pullRequests || 0,
       predictedPullRequests: user.predictedPullRequests || 0,
       reviews: user.reviews || 0,
-      jiraIssues: user.jiraIssues || 0,
+      issueResolutions: user.issueResolutions || 0,
       loc: user.loc || 0,
       filesTouched: user.filesTouched || 0,
       repoBreakdown: user.repoBreakdown || {},
-      jiraBreakdown: user.jiraBreakdown || {},
+      resolutionBreakdown: user.resolutionBreakdown || {},
     };
   });
 });
@@ -172,12 +172,12 @@ dashboardData.periods = dashboardData.periods
   })
   .sort((a, b) => a.startDate.localeCompare(b.startDate));
 
-// Detect whether any period carries Jira data
-dashboardData.hasJira = Object.values(dashboardData.users).some(u =>
-  Object.values(u.data).some(d => (d.jiraIssues || 0) > 0)
+// Detect whether any period carries issue resolution data
+dashboardData.hasIssueResolutions = Object.values(dashboardData.users).some(u =>
+  Object.values(u.data).some(d => (d.issueResolutions || 0) > 0)
 );
 
-const hasJira = dashboardData.hasJira;
+const hasIssueResolutions = dashboardData.hasIssueResolutions;
 
 // ─── Build HTML ─────────────────────────────────────────────────────────────
 
@@ -1362,7 +1362,7 @@ body::after {
         <button class="sort-btn" data-sort="commits" onclick="setUserSort('commits')">Commits</button>
         <button class="sort-btn" data-sort="pullRequests" onclick="setUserSort('pullRequests')">PRs</button>
         <button class="sort-btn" data-sort="reviews" onclick="setUserSort('reviews')">Reviews</button>
-${hasJira ? `<button class="sort-btn" data-sort="jiraIssues" onclick="setUserSort('jiraIssues')">Jira Issues</button>` : ''}
+${hasIssueResolutions ? `<button class="sort-btn" data-sort="issueResolutions" onclick="setUserSort('issueResolutions')">Issue Resolutions</button>` : ''}
         <button class="sort-btn" data-sort="loc" onclick="setUserSort('loc')">LOC</button>
         <button class="sort-btn" data-sort="filesTouched" onclick="setUserSort('filesTouched')">Files</button>
       </div>
@@ -1414,7 +1414,7 @@ ${hasJira ? `<button class="sort-btn" data-sort="jiraIssues" onclick="setUserSor
       </p>
       <div class="meth-formula">
         score = ${Object.entries(WEIGHTS)
-          .filter(([key]) => hasJira || key !== 'jiraIssues')
+          .filter(([key]) => hasIssueResolutions || key !== 'issueResolutions')
           .map(([key, w]) => {
             const label =
               key === 'loc'
@@ -1429,8 +1429,8 @@ ${hasJira ? `<button class="sort-btn" data-sort="jiraIssues" onclick="setUserSor
                         ? 'Commits'
                         : key === 'reviews'
                           ? 'Reviews'
-                          : key === 'jiraIssues'
-                            ? 'Jira Issues'
+                          : key === 'issueResolutions'
+                            ? 'Issue Resolutions'
                             : key;
             if (w >= 1) return label + ' × ' + w;
             return (
@@ -1472,11 +1472,11 @@ ${hasJira ? `<button class="sort-btn" data-sort="jiraIssues" onclick="setUserSor
             <td>High weight — code reviews are critical to quality and team collaboration.</td>
           </tr>
 ${
-  hasJira
+  hasIssueResolutions
     ? `<tr>
-            <td>Jira Issues</td>
-            <td class="meth-mono">${WEIGHTS.jiraIssues}</td>
-            <td>Moderate weight — completed tickets capture delivered work that has no PR, but sit below PRs and reviews because a ticket is often closed by a PR that is already counted.</td>
+            <td>Issue Resolutions</td>
+            <td class="meth-mono">${WEIGHTS.issueResolutions}</td>
+            <td>Moderate weight — resolved issues capture delivered work that has no PR, but sit below PRs and reviews because an issue is often resolved by a PR that is already counted.</td>
           </tr>`
     : ''
 }
@@ -1551,7 +1551,7 @@ ${
           <tr><td>Score</td><td>Weighted composite of all metrics below. Higher is better.</td></tr>
           <tr><td>Pull Requests</td><td>Real PRs merged/opened, or predicted PRs when real data is unavailable.</td></tr>
           <tr><td>Reviews</td><td>Pull request reviews performed (approved, commented, or requested changes).</td></tr>
-${hasJira ? `<tr><td>Jira Issues</td><td>Jira issues completed (resolved) in the period, attributed to their assignee.</td></tr>` : ''}
+${hasIssueResolutions ? `<tr><td>Issue Resolutions</td><td>Jira issues resolved in the period, attributed to their assignee.</td></tr>` : ''}
           <tr><td>Commits</td><td>Total git commits authored across all tracked repositories.</td></tr>
           <tr><td>Lines of Code</td><td>Net lines added (insertions − deletions) across all commits.</td></tr>
           <tr><td>Files Touched</td><td>Unique files modified across all commits in the period.</td></tr>
@@ -1608,12 +1608,12 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
   const GENERATED_AT = '${new Date().toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}';
   const ALL_PERIODS = DATA.periods; // [{id, startDate, endDate}, ...]
   const ALL_PERIOD_IDS = ALL_PERIODS.map(p => p.id);
-  const HAS_JIRA = !!DATA.hasJira;
+  const HAS_ISSUE_RESOLUTIONS = !!DATA.hasIssueResolutions;
   const METRICS = [
     { key: 'score',        label: 'Score',         color: '#00ddcc', format: v => v.toFixed(0) },
     { key: 'effectivePRs', label: 'Pull Requests',  color: '#00aaff', format: v => v.toFixed(0), dataKey: 'effectivePR' },
     { key: 'reviews',      label: 'Reviews',        color: '#cc66ff', format: v => v.toFixed(0) },
-${hasJira ? `    { key: 'jiraIssues',   label: 'Jira Issues',    color: '#4477ff', format: v => v.toFixed(0) },` : ''}
+${hasIssueResolutions ? `    { key: 'issueResolutions', label: 'Issue Resolutions', color: '#4477ff', format: v => v.toFixed(0) },` : ''}
     { key: 'commits',      label: 'Commits',        color: '#22cc44', format: v => v.toFixed(0) },
     { key: 'loc',          label: 'Lines of Code',  color: '#ff8844', format: v => v >= 1000 ? (v/1000).toFixed(1)+'k' : v.toFixed(0) },
     { key: 'filesTouched', label: 'Files Touched',  color: '#ffaa00', format: v => v.toFixed(0) },
@@ -1707,8 +1707,8 @@ ${hasJira ? `    { key: 'jiraIssues',   label: 'Jira Issues',    color: '#4477ff
 
   function getUserTotals(userName, periods) {
     const ud = DATA.users[userName];
-    if (!ud) return { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, jiraIssues:0, loc:0, filesTouched:0 };
-    const totals = { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, jiraIssues:0, loc:0, filesTouched:0 };
+    if (!ud) return { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, issueResolutions:0, loc:0, filesTouched:0 };
+    const totals = { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, issueResolutions:0, loc:0, filesTouched:0 };
     periods.forEach(p => {
       const d = ud.data[p];
       if (d) {
@@ -1718,7 +1718,7 @@ ${hasJira ? `    { key: 'jiraIssues',   label: 'Jira Issues',    color: '#4477ff
         totals.predictedPullRequests += d.predictedPullRequests || 0;
         totals.effectivePRs += d.pullRequests > 0 ? d.pullRequests : (d.predictedPullRequests || 0);
         totals.reviews += d.reviews;
-        totals.jiraIssues += d.jiraIssues || 0;
+        totals.issueResolutions += d.issueResolutions || 0;
         totals.loc += d.loc;
         totals.filesTouched += d.filesTouched;
       }
@@ -2078,7 +2078,7 @@ ${hasJira ? `    { key: 'jiraIssues',   label: 'Jira Issues',    color: '#4477ff
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.commits) + fire('commits') + '</div><div class="stat-label">Commits</div></div>'
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.effectivePRs) + fire('effectivePRs') + '</div><div class="stat-label">PRs</div></div>'
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.reviews) + fire('reviews') + '</div><div class="stat-label">Reviews</div></div>'
-          + (HAS_JIRA ? '<div class="user-stat"><div class="stat-value">' + formatNum(t.jiraIssues) + fire('jiraIssues') + '</div><div class="stat-label">Jira</div></div>' : '')
+          + (HAS_ISSUE_RESOLUTIONS ? '<div class="user-stat"><div class="stat-value">' + formatNum(t.issueResolutions) + fire('issueResolutions') + '</div><div class="stat-label">Issue Res.</div></div>' : '')
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.loc) + fire('loc') + '</div><div class="stat-label">LOC</div></div>'
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.filesTouched) + fire('filesTouched') + '</div><div class="stat-label">Files</div></div>'
         + '</div>'
@@ -2686,7 +2686,7 @@ ${hasJira ? `    { key: 'jiraIssues',   label: 'Jira Issues',    color: '#4477ff
       currentScope = +scope;
     }
     const sort = params.get('sort');
-    if (sort && ['score','commits','pullRequests','reviews','jiraIssues','loc','filesTouched'].includes(sort)) currentSort = sort;
+    if (sort && ['score','commits','pullRequests','reviews','issueResolutions','loc','filesTouched'].includes(sort)) currentSort = sort;
     return {
       tab: params.get('tab') || 'dashboard',
       profile: params.get('profile') || null,

--- a/results-dashboard.js
+++ b/results-dashboard.js
@@ -28,6 +28,9 @@ const dashboardData = {
   periods: [],
   users: {},
   team: [],
+  // Jira is an opt-in integration. When no results file carries Jira data the
+  // dashboard hides the metric entirely rather than showing empty zeroes.
+  hasJira: false,
 };
 
 // First pass: collect all periods with their date ranges
@@ -150,9 +153,11 @@ filteredEntries.forEach(({ entry, startDate, endDate }) => {
       pullRequests: user.pullRequests || 0,
       predictedPullRequests: user.predictedPullRequests || 0,
       reviews: user.reviews || 0,
+      jiraIssues: user.jiraIssues || 0,
       loc: user.loc || 0,
       filesTouched: user.filesTouched || 0,
       repoBreakdown: user.repoBreakdown || {},
+      jiraBreakdown: user.jiraBreakdown || {},
     };
   });
 });
@@ -166,6 +171,13 @@ dashboardData.periods = dashboardData.periods
     return true;
   })
   .sort((a, b) => a.startDate.localeCompare(b.startDate));
+
+// Detect whether any period carries Jira data
+dashboardData.hasJira = Object.values(dashboardData.users).some(u =>
+  Object.values(u.data).some(d => (d.jiraIssues || 0) > 0)
+);
+
+const hasJira = dashboardData.hasJira;
 
 // ─── Build HTML ─────────────────────────────────────────────────────────────
 
@@ -1350,6 +1362,7 @@ body::after {
         <button class="sort-btn" data-sort="commits" onclick="setUserSort('commits')">Commits</button>
         <button class="sort-btn" data-sort="pullRequests" onclick="setUserSort('pullRequests')">PRs</button>
         <button class="sort-btn" data-sort="reviews" onclick="setUserSort('reviews')">Reviews</button>
+${hasJira ? `<button class="sort-btn" data-sort="jiraIssues" onclick="setUserSort('jiraIssues')">Jira Issues</button>` : ''}
         <button class="sort-btn" data-sort="loc" onclick="setUserSort('loc')">LOC</button>
         <button class="sort-btn" data-sort="filesTouched" onclick="setUserSort('filesTouched')">Files</button>
       </div>
@@ -1401,6 +1414,7 @@ body::after {
       </p>
       <div class="meth-formula">
         score = ${Object.entries(WEIGHTS)
+          .filter(([key]) => hasJira || key !== 'jiraIssues')
           .map(([key, w]) => {
             const label =
               key === 'loc'
@@ -1415,7 +1429,9 @@ body::after {
                         ? 'Commits'
                         : key === 'reviews'
                           ? 'Reviews'
-                          : key;
+                          : key === 'jiraIssues'
+                            ? 'Jira Issues'
+                            : key;
             if (w >= 1) return label + ' × ' + w;
             return (
               label +
@@ -1455,6 +1471,15 @@ body::after {
             <td class="meth-mono">${WEIGHTS.reviews}</td>
             <td>High weight — code reviews are critical to quality and team collaboration.</td>
           </tr>
+${
+  hasJira
+    ? `<tr>
+            <td>Jira Issues</td>
+            <td class="meth-mono">${WEIGHTS.jiraIssues}</td>
+            <td>Moderate weight — completed tickets capture delivered work that has no PR, but sit below PRs and reviews because a ticket is often closed by a PR that is already counted.</td>
+          </tr>`
+    : ''
+}
           <tr>
             <td>Commits</td>
             <td class="meth-mono">${WEIGHTS.commits}</td>
@@ -1526,6 +1551,7 @@ body::after {
           <tr><td>Score</td><td>Weighted composite of all metrics below. Higher is better.</td></tr>
           <tr><td>Pull Requests</td><td>Real PRs merged/opened, or predicted PRs when real data is unavailable.</td></tr>
           <tr><td>Reviews</td><td>Pull request reviews performed (approved, commented, or requested changes).</td></tr>
+${hasJira ? `<tr><td>Jira Issues</td><td>Jira issues completed (resolved) in the period, attributed to their assignee.</td></tr>` : ''}
           <tr><td>Commits</td><td>Total git commits authored across all tracked repositories.</td></tr>
           <tr><td>Lines of Code</td><td>Net lines added (insertions − deletions) across all commits.</td></tr>
           <tr><td>Files Touched</td><td>Unique files modified across all commits in the period.</td></tr>
@@ -1582,10 +1608,12 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
   const GENERATED_AT = '${new Date().toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}';
   const ALL_PERIODS = DATA.periods; // [{id, startDate, endDate}, ...]
   const ALL_PERIOD_IDS = ALL_PERIODS.map(p => p.id);
+  const HAS_JIRA = !!DATA.hasJira;
   const METRICS = [
     { key: 'score',        label: 'Score',         color: '#00ddcc', format: v => v.toFixed(0) },
     { key: 'effectivePRs', label: 'Pull Requests',  color: '#00aaff', format: v => v.toFixed(0), dataKey: 'effectivePR' },
     { key: 'reviews',      label: 'Reviews',        color: '#cc66ff', format: v => v.toFixed(0) },
+${hasJira ? `    { key: 'jiraIssues',   label: 'Jira Issues',    color: '#4477ff', format: v => v.toFixed(0) },` : ''}
     { key: 'commits',      label: 'Commits',        color: '#22cc44', format: v => v.toFixed(0) },
     { key: 'loc',          label: 'Lines of Code',  color: '#ff8844', format: v => v >= 1000 ? (v/1000).toFixed(1)+'k' : v.toFixed(0) },
     { key: 'filesTouched', label: 'Files Touched',  color: '#ffaa00', format: v => v.toFixed(0) },
@@ -1679,8 +1707,8 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
 
   function getUserTotals(userName, periods) {
     const ud = DATA.users[userName];
-    if (!ud) return { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, loc:0, filesTouched:0 };
-    const totals = { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, loc:0, filesTouched:0 };
+    if (!ud) return { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, jiraIssues:0, loc:0, filesTouched:0 };
+    const totals = { score:0, commits:0, pullRequests:0, predictedPullRequests:0, effectivePRs:0, reviews:0, jiraIssues:0, loc:0, filesTouched:0 };
     periods.forEach(p => {
       const d = ud.data[p];
       if (d) {
@@ -1690,6 +1718,7 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
         totals.predictedPullRequests += d.predictedPullRequests || 0;
         totals.effectivePRs += d.pullRequests > 0 ? d.pullRequests : (d.predictedPullRequests || 0);
         totals.reviews += d.reviews;
+        totals.jiraIssues += d.jiraIssues || 0;
         totals.loc += d.loc;
         totals.filesTouched += d.filesTouched;
       }
@@ -2049,6 +2078,7 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.commits) + fire('commits') + '</div><div class="stat-label">Commits</div></div>'
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.effectivePRs) + fire('effectivePRs') + '</div><div class="stat-label">PRs</div></div>'
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.reviews) + fire('reviews') + '</div><div class="stat-label">Reviews</div></div>'
+          + (HAS_JIRA ? '<div class="user-stat"><div class="stat-value">' + formatNum(t.jiraIssues) + fire('jiraIssues') + '</div><div class="stat-label">Jira</div></div>' : '')
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.loc) + fire('loc') + '</div><div class="stat-label">LOC</div></div>'
           + '<div class="user-stat"><div class="stat-value">' + formatNum(t.filesTouched) + fire('filesTouched') + '</div><div class="stat-label">Files</div></div>'
         + '</div>'
@@ -2656,7 +2686,7 @@ window.__REPO_HERO_DATA__ = ${JSON.stringify(dashboardData)};
       currentScope = +scope;
     }
     const sort = params.get('sort');
-    if (sort && ['score','commits','pullRequests','reviews','loc','filesTouched'].includes(sort)) currentSort = sort;
+    if (sort && ['score','commits','pullRequests','reviews','jiraIssues','loc','filesTouched'].includes(sort)) currentSort = sort;
     return {
       tab: params.get('tab') || 'dashboard',
       profile: params.get('profile') || null,

--- a/results-reindexer.js
+++ b/results-reindexer.js
@@ -139,9 +139,11 @@ files.forEach(file => {
         loc: 0,
         filesTouched: 0,
         reviews: 0,
+        jiraIssues: 0,
         score: 0,
         predictedPullRequests: 0,
         repoBreakdown: {},
+        jiraBreakdown: {},
       };
     } else if (oldName !== newName || merged[newName]._seen) {
       fileMerges++;
@@ -154,6 +156,7 @@ files.forEach(file => {
     merged[newName].loc += user.loc || 0;
     merged[newName].filesTouched += user.filesTouched || 0;
     merged[newName].reviews += user.reviews || 0;
+    merged[newName].jiraIssues += user.jiraIssues || 0;
     merged[newName].predictedPullRequests += user.predictedPullRequests || 0;
 
     // Merge repoBreakdown
@@ -177,6 +180,16 @@ files.forEach(file => {
           rb.filesTouched || 0;
       });
     }
+
+    // Merge jiraBreakdown
+    if (user.jiraBreakdown) {
+      Object.entries(user.jiraBreakdown).forEach(([project, count]) => {
+        if (!merged[newName].jiraBreakdown[project]) {
+          merged[newName].jiraBreakdown[project] = 0;
+        }
+        merged[newName].jiraBreakdown[project] += count || 0;
+      });
+    }
   });
 
   // Step 2: Re-calculate scores
@@ -186,6 +199,8 @@ files.forEach(file => {
     if (!user.predictedPullRequests) delete user.predictedPullRequests;
     // Remove empty repoBreakdown
     if (Object.keys(user.repoBreakdown).length === 0) delete user.repoBreakdown;
+    // Remove empty jiraBreakdown
+    if (Object.keys(user.jiraBreakdown).length === 0) delete user.jiraBreakdown;
     user.score = calculateScore(user);
   });
 

--- a/results-reindexer.js
+++ b/results-reindexer.js
@@ -139,11 +139,11 @@ files.forEach(file => {
         loc: 0,
         filesTouched: 0,
         reviews: 0,
-        jiraIssues: 0,
+        issueResolutions: 0,
         score: 0,
         predictedPullRequests: 0,
         repoBreakdown: {},
-        jiraBreakdown: {},
+        resolutionBreakdown: {},
       };
     } else if (oldName !== newName || merged[newName]._seen) {
       fileMerges++;
@@ -156,7 +156,7 @@ files.forEach(file => {
     merged[newName].loc += user.loc || 0;
     merged[newName].filesTouched += user.filesTouched || 0;
     merged[newName].reviews += user.reviews || 0;
-    merged[newName].jiraIssues += user.jiraIssues || 0;
+    merged[newName].issueResolutions += user.issueResolutions || 0;
     merged[newName].predictedPullRequests += user.predictedPullRequests || 0;
 
     // Merge repoBreakdown
@@ -181,13 +181,13 @@ files.forEach(file => {
       });
     }
 
-    // Merge jiraBreakdown
-    if (user.jiraBreakdown) {
-      Object.entries(user.jiraBreakdown).forEach(([project, count]) => {
-        if (!merged[newName].jiraBreakdown[project]) {
-          merged[newName].jiraBreakdown[project] = 0;
+    // Merge resolutionBreakdown
+    if (user.resolutionBreakdown) {
+      Object.entries(user.resolutionBreakdown).forEach(([project, count]) => {
+        if (!merged[newName].resolutionBreakdown[project]) {
+          merged[newName].resolutionBreakdown[project] = 0;
         }
-        merged[newName].jiraBreakdown[project] += count || 0;
+        merged[newName].resolutionBreakdown[project] += count || 0;
       });
     }
   });
@@ -199,8 +199,9 @@ files.forEach(file => {
     if (!user.predictedPullRequests) delete user.predictedPullRequests;
     // Remove empty repoBreakdown
     if (Object.keys(user.repoBreakdown).length === 0) delete user.repoBreakdown;
-    // Remove empty jiraBreakdown
-    if (Object.keys(user.jiraBreakdown).length === 0) delete user.jiraBreakdown;
+    // Remove empty resolutionBreakdown
+    if (Object.keys(user.resolutionBreakdown).length === 0)
+      delete user.resolutionBreakdown;
     user.score = calculateScore(user);
   });
 

--- a/sample-configs/treering.json
+++ b/sample-configs/treering.json
@@ -118,7 +118,16 @@
     "AI Bots"
   ],
   "tokens": {
-    "github": "ghp_XXXXXX"
+    "github": "ghp_XXXXXX",
+    "jira": {
+      "email": "you@treering.com",
+      "apiToken": "ATATT_XXXXXX"
+    }
+  },
+  "jira": {
+    "baseUrl": "https://treering.atlassian.net",
+    "projects": ["TR", "CNSL"],
+    "excludeIssueTypes": ["Epic"]
   },
   "commitsPerPullRequest": 12.5
 }

--- a/score.js
+++ b/score.js
@@ -12,11 +12,11 @@ const WEIGHTS = {
   predictedPullRequests: 15,
   commits: 1 / 100,
   reviews: 17,
-  // Completed Jira issues sit below pullRequests (15) and reviews (17). A ticket
-  // is a meaningful unit of delivered work, but it is a coarser signal and is
-  // frequently closed by a pull request that is already being counted, so the
+  // Issue resolutions sit below pullRequests (15) and reviews (17). A resolved
+  // issue is a meaningful unit of delivered work, but it is a coarser signal and
+  // is frequently closed by a pull request that is already being counted, so the
   // weight is deliberately lower to limit double counting.
-  jiraIssues: 10,
+  issueResolutions: 10,
 };
 
 /**
@@ -25,7 +25,7 @@ const WEIGHTS = {
  * Uses real pullRequests when available, otherwise falls back to
  * predictedPullRequests (synthesized from commits-per-PR ratios).
  *
- * @param {{ loc?: number, filesTouched?: number, pullRequests?: number, predictedPullRequests?: number, commits?: number, reviews?: number, jiraIssues?: number }} user
+ * @param {{ loc?: number, filesTouched?: number, pullRequests?: number, predictedPullRequests?: number, commits?: number, reviews?: number, issueResolutions?: number }} user
  * @returns {number}
  */
 function calculateScore(user) {
@@ -39,7 +39,7 @@ function calculateScore(user) {
     effectivePrs * WEIGHTS.pullRequests +
     (user.commits || 0) * WEIGHTS.commits +
     (user.reviews || 0) * WEIGHTS.reviews +
-    (user.jiraIssues || 0) * WEIGHTS.jiraIssues;
+    (user.issueResolutions || 0) * WEIGHTS.issueResolutions;
 
   return score || 0;
 }

--- a/score.js
+++ b/score.js
@@ -12,6 +12,11 @@ const WEIGHTS = {
   predictedPullRequests: 15,
   commits: 1 / 100,
   reviews: 17,
+  // Completed Jira issues sit below pullRequests (15) and reviews (17). A ticket
+  // is a meaningful unit of delivered work, but it is a coarser signal and is
+  // frequently closed by a pull request that is already being counted, so the
+  // weight is deliberately lower to limit double counting.
+  jiraIssues: 10,
 };
 
 /**
@@ -20,7 +25,7 @@ const WEIGHTS = {
  * Uses real pullRequests when available, otherwise falls back to
  * predictedPullRequests (synthesized from commits-per-PR ratios).
  *
- * @param {{ loc?: number, filesTouched?: number, pullRequests?: number, predictedPullRequests?: number, commits?: number, reviews?: number }} user
+ * @param {{ loc?: number, filesTouched?: number, pullRequests?: number, predictedPullRequests?: number, commits?: number, reviews?: number, jiraIssues?: number }} user
  * @returns {number}
  */
 function calculateScore(user) {
@@ -33,7 +38,8 @@ function calculateScore(user) {
     (user.filesTouched || 0) * WEIGHTS.filesTouched +
     effectivePrs * WEIGHTS.pullRequests +
     (user.commits || 0) * WEIGHTS.commits +
-    (user.reviews || 0) * WEIGHTS.reviews;
+    (user.reviews || 0) * WEIGHTS.reviews +
+    (user.jiraIssues || 0) * WEIGHTS.jiraIssues;
 
   return score || 0;
 }


### PR DESCRIPTION
## Summary

Adds an **opt-in Jira Cloud integration** to Repo Hero that produces a new **Issue Resolutions** metric, counting issues each contributor resolved in a period alongside commits, pull requests, and reviews. Assignees are resolved through the **existing `aliases` map**, so a person's resolutions roll up into the same record as the rest of their contributions.

## Configuration

Two new optional `config.json` blocks:

```jsonc
{
  "tokens": {
    "jira": {
      "email": "you@yourcompany.com",
      "apiToken": "ATATTxxxxxxxxxxxx"
    }
  },
  "jira": {
    "baseUrl": "https://yourorg.atlassian.net",
    "projects": ["ENG", "OPS"],
    "completedJql": null,
    "excludeIssueTypes": ["Epic"]
  }
}
```

Both are optional. When either is missing or incomplete, the run warns once and continues with GitHub-only metrics, and the dashboard hides the Issue Resolutions metric entirely rather than showing empty zeroes.

## Naming

The PR deliberately separates **the source system** from **the metric it produces**:

- **Jira** names the integration and its transport — the `jira` config block, `tokens.jira`, and the internal API plumbing (`_JIRA_API`, `getFromJiraAPI()`, `fetchCompletedJiraIssues()`, the `jira:` cache-key prefix, etc.).
- **Issue Resolutions** names everything measured, stored, scored, exported, and displayed — `issueResolutions`, `resolutionBreakdown`, `totalIssueResolutions`, `WEIGHTS.issueResolutions`, and `trending_issueResolutions.csv`.

The compact user-card stat tile reads **"Issue Res."** so it fits the 3-column grid alongside "PRs", "LOC", and "Files".

## Changes

**Gathering** (`gather-and-rank.js`)
- Queries `/rest/api/3/search/jql` per configured project for issues resolved inside the reporting window, paginating via `nextPageToken`
- Responses reuse the existing on-disk cache with `jira:`-prefixed keys, plus a `resolutiondate` staleness check mirroring the GitHub `created:` check so a week cached while still in the future is refetched
- Credentials validated against `/rest/api/3/myself`; a failure disables the Jira pass for the run rather than aborting the whole gather
- Extracts the shared cache loader out of `getFromGitHubAPI` into `_loadCache()` so both API layers populate the same in-memory cache regardless of which runs first

**What counts as a resolution** — by default an issue counts when it sits in the `Done` status category and its `resolutiondate` falls inside the period. Boards that don't follow that convention can override the predicate with `completedJql`; the project and date-range clauses are still applied on top so weekly bucketing stays correct.

**Assignee attribution** — resolved in order: Jira display name → email address → email local part → account ID. Most Jira Cloud sites hide email addresses for privacy, so the display name usually carries the match. Unassigned issues are skipped and reported in the run summary.

**Scoring** (`score.js`) — new `issueResolutions` weight of **10**, deliberately below `pullRequests` (15) and `reviews` (17) because an issue is frequently resolved by a PR that is already being counted.

**Reporting** — `issueResolutions` / `resolutionBreakdown` flow through `results-reindexer.js` (alias merges), `results-charter.js` (`trending_issueResolutions.csv`), `results-cache-cleanup.js` (stale Jira cache pruning), and `results-dashboard.js` (stat tile, sort option, trend chart, methodology + metric-definition tables).

**Docs** — README configuration reference and a new "Jira Integration" section, scoring table, features list, `help.js`, and a placeholder-only `sample-configs/treering.json` entry.

## Testing

- **Live JQL validation** — the generated query was run against the real Jira Cloud instance and returns the expected issues; confirmed `nextPageToken` / `isLast` pagination semantics and that assignee emails are withheld (validating the display-name-first resolution order)
- **Alias resolution** — verified display names, email addresses, email local parts, canonical alias keys, unknown users, and unassigned issues all map as expected against the real alias config
- **Integration test against a mock Jira server** — Basic auth header, credential validation, multi-page pagination, multi-project aggregation, per-project breakdown, unassigned handling, and score contribution all pass, asserting the renamed field names and that the old keys are absent and contribute nothing to the score
- **Graceful degradation** — no `jira` block, missing credentials, empty `projects`, malformed `baseUrl`, and a 401 response each disable the metric cleanly without failing the run
- **Regression** — re-ran a real gather for an existing week and diffed against the pre-change output: `totalCommits`, `totalPullRequests`, `activeUsers`, and every per-user metric are identical, confirming the cache refactor is behavior-preserving
- **Dashboard** — regenerated in both states and asserted 16 conditions: with no data the sort button, `METRICS` entry, methodology row, and formula term are all absent; with data present the sort button, label, tile, weight row, formula term, definition row, and sort whitelist all render, the client script parses, and no legacy identifiers survive
- `prettier --write` clean

## Backwards Compatibility

Every new field is optional. Result files written before this change have no `issueResolutions` and score exactly as they did before (weight × 0). The rename carries no migration cost — the metric is unreleased, so no result file contains the earlier field names.

## Notes for Review

The resolution definition (`resolutiondate` within the window vs. a changelog-derived status transition) was chosen for stability and cost — it needs no changelog expansion and matches the pipeline's weekly bucketing. `completedJql` is the escape hatch if a given board needs different semantics.
