### PR TITLE
Add optional email delivery of the dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A configurable CLI toolkit for analyzing the health of git repositories and thei
 - **Re-indexer** — retroactively apply alias or ignore-user changes to all historical result files
 - **Future date capping** — if the configured end date extends past today, it is automatically clamped to the current date
 - **CSV export** — per-user and team-level CSV files for use in spreadsheets or external tools
+- **Email delivery** — optionally attach the portable dashboard to an email and send it to a list of recipients on every run
 
 ---
 
@@ -78,6 +79,68 @@ Create a `config.json` in the project root (it is gitignored). All top-level pro
 }
 ```
 
+### Email Delivery
+
+Optionally email the generated dashboard to one or more recipients. When the
+dashboard is regenerated it is opened in your browser **and** sent to everyone on
+the list, so a recurring `npm start` doubles as a scheduled report.
+
+Add a `tokens.smtp` credential pair and an `email` block:
+
+```jsonc
+{
+  "tokens": {
+    "smtp": {
+      "user": "reports@yourcompany.com", // SMTP username
+      "pass": "xxxxxxxxxxxxxxxx", // SMTP password or app password
+    },
+  },
+  "email": {
+    "to": ["lead@yourcompany.com", "vp@yourcompany.com"], // one or more recipients
+    "cc": [], // optional
+    "bcc": [], // optional
+    "from": "Repo Hero <reports@yourcompany.com>", // optional, defaults to tokens.smtp.user
+    "subject": "Repo Hero Dashboard — {range}", // optional, supports placeholders
+    "compress": false, // optional, attach dashboard.html.gz instead
+    "maxAttachmentMB": 20, // optional, skip send above this encoded size
+    "enabled": true, // optional, set false to disable without deleting the block
+    "smtp": {
+      "host": "smtp.gmail.com", // required
+      "port": 587, // optional, defaults to 587
+      "secure": false, // optional, inferred from the port
+    },
+  },
+}
+```
+
+`to` accepts either a single address string or an array. Addresses may be bare
+(`you@company.com`) or include a display name (`You <you@company.com>`).
+
+**Subject placeholders** — `{range}`, `{startDate}`, `{endDate}`, `{periods}`,
+and `{date}`.
+
+**Ports** — `secure` defaults to `true` on port 465 (implicit TLS) and `false`
+on 587 or 25 (STARTTLS). Set it explicitly to override.
+
+**Attachment size** — the dashboard inlines all of its data, so it grows with
+your history and can exceed a mail server's message limit. Base64 encoding adds
+another third on the wire. Setting `"compress": true` attaches a gzipped
+dashboard, which typically shrinks it by more than 10x. Recipients on macOS and
+Linux can open the `.gz` by double-clicking it.
+
+**Gmail** — use an [app password](https://myaccount.google.com/apppasswords)
+rather than your account password.
+
+Email delivery is entirely optional. With no `email` block Repo Hero behaves
+exactly as before. If the block is present but unusable, the problem is reported
+and the run still finishes — a mail outage never costs you the dashboard.
+
+To email the dashboard already on disk without regenerating it:
+
+```sh
+npm run email
+```
+
 ### Quick Reconfigure
 
 ```sh
@@ -101,6 +164,7 @@ npm run config 2024-06
 | `npm run combine`       | Merge all `.results_history/*.json` into `combined_results.json`               |
 | `npm run chart`         | Regenerate CSV files and dashboard from combined results                       |
 | `npm run dashboard`     | Regenerate only the HTML dashboard                                             |
+| `npm run email`         | Email the existing dashboard without regenerating it                           |
 | `npm run reindex`       | Re-apply alias and ignore-user changes to all result files                     |
 | `npm run cleanup`       | Remove orphaned cache files (use `-- --dry` to preview)                        |
 | `npm run config <date>` | Quick-reconfigure `config.json` for a year or month                            |
@@ -265,6 +329,7 @@ repo-hero/
 ├── results-team-charter.js   Team CSV generation
 ├── active-users-by-date.js   Active user count CSV
 ├── results-dashboard.js      HTML dashboard generator
+├── email-dashboard.js        Emails the dashboard to configured recipients
 ├── results-reindexer.js      Retroactive alias/ignore re-indexer
 ├── results-cache-cleanup.js  Prune orphaned result files from cache
 ├── configurator.js           Quick date reconfiguration CLI

--- a/email-dashboard.js
+++ b/email-dashboard.js
@@ -1,0 +1,421 @@
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+
+const resultsDir = path.join(__dirname, '.results_history');
+const dashboardFile = path.join(resultsDir, 'dashboard.html');
+const configFile = path.join(__dirname, 'config.json');
+
+// Most providers reject messages larger than 25 MB, and base64 inflates an
+// attachment by roughly a third. Warn well before the wire size gets there.
+const DEFAULT_MAX_ATTACHMENT_MB = 20;
+const BASE64_OVERHEAD = 4 / 3;
+
+const formatSize = bytes => {
+  if (bytes >= 1048576) return (bytes / 1048576).toFixed(1) + ' MB';
+  if (bytes >= 1024) return (bytes / 1024).toFixed(1) + ' KB';
+  return bytes + ' B';
+};
+
+// ─── Config ─────────────────────────────────────────────────────────────────
+
+/**
+ * Reads config.json from disk. Returns an empty object when it is missing or
+ * unparseable so a bad config degrades to "email not configured" rather than
+ * taking down the dashboard run.
+ */
+function loadConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(configFile, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Accepts either a single address or a list of them and returns a de-duplicated
+ * array of trimmed, non-empty addresses.
+ *
+ * @param {string|string[]|undefined} value raw recipient value from config
+ * @returns {string[]} normalized recipient list
+ */
+function normalizeRecipients(value) {
+  if (!value) return [];
+
+  const list = Array.isArray(value) ? value : [value];
+  const seen = new Set();
+
+  return list
+    .filter(entry => typeof entry === 'string')
+    .map(entry => entry.trim())
+    .filter(entry => {
+      if (!entry) return false;
+
+      const key = entry.toLowerCase();
+      if (seen.has(key)) return false;
+
+      seen.add(key);
+
+      return true;
+    });
+}
+
+/**
+ * A permissive check that catches typos and obviously malformed entries without
+ * trying to fully implement RFC 5322. Supports both "user@host" and the
+ * "Display Name <user@host>" form nodemailer accepts.
+ *
+ * @param {string} address address to test
+ * @returns {boolean} whether the address is plausibly deliverable
+ */
+function isValidAddress(address) {
+  const bracketed = address.match(/<([^>]+)>\s*$/);
+  const bare = bracketed ? bracketed[1].trim() : address;
+
+  return /^[^\s@]+@[^\s@.]+(\.[^\s@.]+)+$/.test(bare);
+}
+
+/**
+ * Validates the `email` config block and its `tokens.smtp` credentials.
+ *
+ * Email delivery is opt-in: a config with no `email` block resolves as disabled
+ * with no warnings. A config that is present but unusable resolves as disabled
+ * *with* warnings, so a typo is reported rather than silently dropping the
+ * report.
+ *
+ * @param {object} config parsed config.json
+ * @returns {{enabled: boolean, warnings: string[], settings: object|null}} resolution
+ */
+function resolveEmailConfig(config) {
+  const warnings = [];
+  const email = config?.email;
+
+  if (!email || typeof email !== 'object') {
+    return { enabled: false, warnings, settings: null };
+  }
+
+  if (email.enabled === false) {
+    return { enabled: false, warnings, settings: null };
+  }
+
+  const to = normalizeRecipients(email.to);
+  const cc = normalizeRecipients(email.cc);
+  const bcc = normalizeRecipients(email.bcc);
+  const smtp = email.smtp || {};
+  const credentials = config?.tokens?.smtp || {};
+
+  if (to.length === 0) {
+    warnings.push('"email.to" must list at least one recipient address.');
+  }
+
+  [...to, ...cc, ...bcc].forEach(address => {
+    if (!isValidAddress(address)) {
+      warnings.push(`"${address}" is not a valid email address.`);
+    }
+  });
+
+  if (!smtp.host) {
+    warnings.push('"email.smtp.host" is required.');
+  }
+
+  if (!credentials.user || !credentials.pass) {
+    warnings.push(
+      '"tokens.smtp.user" and "tokens.smtp.pass" are both required.'
+    );
+  }
+
+  // Fall back to the authenticating account so a minimal config still produces
+  // a deliverable From header.
+  const from = email.from || credentials.user;
+
+  if (!from) {
+    warnings.push('"email.from" is required when "tokens.smtp.user" is unset.');
+  }
+
+  if (warnings.length > 0) {
+    return { enabled: false, warnings, settings: null };
+  }
+
+  const port = Number(smtp.port) || 587;
+
+  return {
+    enabled: true,
+    warnings,
+    settings: {
+      to,
+      cc,
+      bcc,
+      from,
+      subject: email.subject || 'Repo Hero Dashboard — {range}',
+      compress: email.compress === true,
+      maxAttachmentMB:
+        Number(email.maxAttachmentMB) > 0
+          ? Number(email.maxAttachmentMB)
+          : DEFAULT_MAX_ATTACHMENT_MB,
+      smtp: {
+        host: smtp.host,
+        port,
+        // Port 465 is implicit TLS; 587 and 25 negotiate STARTTLS instead.
+        secure: typeof smtp.secure === 'boolean' ? smtp.secure : port === 465,
+        auth: { user: credentials.user, pass: credentials.pass },
+        ...(smtp.tls ? { tls: smtp.tls } : {}),
+      },
+    },
+  };
+}
+
+// ─── Message construction ───────────────────────────────────────────────────
+
+/**
+ * Substitutes {range}, {startDate}, {endDate}, {periods} and {date} into a
+ * subject template. Unknown placeholders are left untouched.
+ *
+ * @param {string} template subject template
+ * @param {object} meta reporting metadata
+ * @returns {string} rendered subject
+ */
+function renderSubject(template, meta) {
+  const range =
+    meta.startDate && meta.endDate
+      ? `${meta.startDate} — ${meta.endDate}`
+      : 'all time';
+
+  const values = {
+    range,
+    startDate: meta.startDate || '',
+    endDate: meta.endDate || '',
+    periods: meta.periods != null ? String(meta.periods) : '',
+    date: meta.generatedAt || new Date().toISOString().split('T')[0],
+  };
+
+  return template.replace(/\{(\w+)\}/g, (match, key) =>
+    key in values ? values[key] : match
+  );
+}
+
+/**
+ * Builds the plain-text and HTML message bodies. The dashboard itself is the
+ * payload, so the body stays a short pointer to the attachment.
+ *
+ * @param {object} meta reporting metadata
+ * @param {string} filename attachment filename
+ * @returns {{text: string, html: string}} message bodies
+ */
+function renderBody(meta, filename) {
+  const lines = [];
+
+  if (meta.startDate && meta.endDate) {
+    lines.push(`Data range: ${meta.startDate} — ${meta.endDate}`);
+  }
+
+  if (meta.periods != null) {
+    lines.push(`Periods: ${meta.periods}`);
+  }
+
+  if (meta.generatedAt) {
+    lines.push(`Generated: ${meta.generatedAt}`);
+  }
+
+  const text = [
+    'The latest Repo Hero dashboard is attached.',
+    '',
+    ...lines,
+    '',
+    filename.endsWith('.gz')
+      ? `Decompress ${filename} and open the resulting HTML file in any browser.`
+      : `Open ${filename} in any browser — it is fully self-contained and needs no server.`,
+  ].join('\n');
+
+  const html = `<div style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;font-size:14px;line-height:1.6;color:#1f2328">
+  <p>The latest <strong>Repo Hero</strong> dashboard is attached.</p>
+  ${lines.length ? `<ul>${lines.map(line => `<li>${line}</li>`).join('')}</ul>` : ''}
+  <p style="color:#59636e">${
+    filename.endsWith('.gz')
+      ? `Decompress <code>${filename}</code> and open the resulting HTML file in any browser.`
+      : `Open <code>${filename}</code> in any browser — it is fully self-contained and needs no server.`
+  }</p>
+</div>`;
+
+  return { text, html };
+}
+
+/**
+ * Reads dashboard.html and, when compression is enabled, gzips it. The
+ * dashboard inlines all of its data and assets, so it compresses by better than
+ * 10x — worth it when a report is too large for a recipient's mail server.
+ *
+ * @param {boolean} compress whether to gzip the attachment
+ * @returns {{filename: string, content: Buffer, rawSize: number}} attachment
+ */
+function buildAttachment(compress) {
+  const raw = fs.readFileSync(dashboardFile);
+
+  if (!compress) {
+    return { filename: 'dashboard.html', content: raw, rawSize: raw.length };
+  }
+
+  return {
+    filename: 'dashboard.html.gz',
+    content: zlib.gzipSync(raw, { level: 9 }),
+    rawSize: raw.length,
+  };
+}
+
+// ─── Delivery ───────────────────────────────────────────────────────────────
+
+/**
+ * Emails the generated dashboard to the configured recipients.
+ *
+ * Never throws. Delivery is a convenience layered on top of the report, so a
+ * misconfigured mailbox or an unreachable SMTP host reports the problem and
+ * lets the pipeline finish successfully.
+ *
+ * @param {object} [meta] reporting metadata used for the subject and body
+ * @param {string} [meta.startDate] first period start date
+ * @param {string} [meta.endDate] last period end date
+ * @param {number} [meta.periods] number of periods represented
+ * @param {string} [meta.generatedAt] dashboard generation timestamp
+ * @param {object} [config] parsed config.json; read from disk when omitted
+ * @returns {Promise<{sent: boolean, reason?: string, recipients?: string[]}>} outcome
+ */
+async function sendDashboardEmail(meta = {}, config = loadConfig()) {
+  const { enabled, warnings, settings } = resolveEmailConfig(config);
+
+  if (!enabled) {
+    if (warnings.length > 0) {
+      console.warn('Email delivery is misconfigured. Skipping.');
+      warnings.forEach(warning => console.warn(`  - ${warning}`));
+
+      return { sent: false, reason: 'invalid-config' };
+    }
+
+    return { sent: false, reason: 'not-configured' };
+  }
+
+  if (!fs.existsSync(dashboardFile)) {
+    console.warn(
+      'dashboard.html not found. Run "npm run dashboard" first. Skipping email.'
+    );
+
+    return { sent: false, reason: 'missing-dashboard' };
+  }
+
+  const attachment = buildAttachment(settings.compress);
+  const wireSize = Math.ceil(attachment.content.length * BASE64_OVERHEAD);
+  const limit = settings.maxAttachmentMB * 1048576;
+
+  if (wireSize > limit) {
+    console.warn(
+      `Dashboard attachment is ${formatSize(wireSize)} encoded, over the ${settings.maxAttachmentMB} MB limit. Skipping email.`
+    );
+
+    if (!settings.compress) {
+      console.warn(
+        '  Set "email.compress": true to attach a gzipped dashboard instead.'
+      );
+    }
+
+    return { sent: false, reason: 'too-large' };
+  }
+
+  const recipients = [...settings.to, ...settings.cc, ...settings.bcc];
+  const subject = renderSubject(settings.subject, meta);
+  const { text, html } = renderBody(meta, attachment.filename);
+
+  try {
+    const nodemailer = require('nodemailer');
+    const transport = nodemailer.createTransport(settings.smtp);
+
+    await transport.sendMail({
+      from: settings.from,
+      to: settings.to,
+      ...(settings.cc.length ? { cc: settings.cc } : {}),
+      ...(settings.bcc.length ? { bcc: settings.bcc } : {}),
+      subject,
+      text,
+      html,
+      attachments: [
+        {
+          filename: attachment.filename,
+          content: attachment.content,
+          contentType: settings.compress ? 'application/gzip' : 'text/html',
+        },
+      ],
+    });
+
+    transport.close();
+
+    const sizeNote = settings.compress
+      ? `${formatSize(attachment.content.length)}, compressed from ${formatSize(attachment.rawSize)}`
+      : formatSize(attachment.content.length);
+
+    console.log(
+      `Dashboard emailed to ${recipients.length} recipient${recipients.length === 1 ? '' : 's'} (${sizeNote}): ${recipients.join(', ')}`
+    );
+
+    return { sent: true, recipients };
+  } catch (error) {
+    console.warn(`Failed to email the dashboard: ${error.message}`);
+
+    return { sent: false, reason: 'send-failed' };
+  }
+}
+
+module.exports = {
+  sendDashboardEmail,
+  resolveEmailConfig,
+  normalizeRecipients,
+  isValidAddress,
+  renderSubject,
+};
+
+// ─── CLI ────────────────────────────────────────────────────────────────────
+// Running this file directly emails the dashboard that is already on disk,
+// without regenerating it or opening a browser.
+
+if (require.main === module) {
+  const config = loadConfig();
+  const { enabled, warnings } = resolveEmailConfig(config);
+
+  if (!enabled && warnings.length === 0) {
+    console.error(
+      'No "email" block found in config.json. See the README for setup.'
+    );
+    process.exit(1);
+  }
+
+  sendDashboardEmail(readDashboardMeta(), config).then(result => {
+    if (!result.sent) process.exit(1);
+  });
+}
+
+/**
+ * Recovers the reporting metadata the dashboard was built from so the standalone
+ * CLI produces the same subject line the pipeline would.
+ *
+ * @returns {object} reporting metadata, or an empty object when unavailable
+ */
+function readDashboardMeta() {
+  const combinedFile = path.join(resultsDir, 'combined_results.json');
+
+  try {
+    const raw = JSON.parse(fs.readFileSync(combinedFile, 'utf8'));
+    const keys = Object.keys(raw)
+      .filter(key => key !== 'combined_results')
+      .sort();
+
+    if (keys.length === 0) return {};
+
+    const first = raw[keys[0]]?._report_info;
+    const last = raw[keys[keys.length - 1]]?._report_info;
+
+    return {
+      startDate: first?.start_date || keys[0].split('_')[0],
+      endDate: last?.end_date || keys[keys.length - 1].split('_').pop(),
+      periods: keys.length,
+      generatedAt: fs.statSync(dashboardFile).mtime.toISOString().split('T')[0],
+    };
+  } catch {
+    return {};
+  }
+}

--- a/help.js
+++ b/help.js
@@ -54,6 +54,9 @@ console.log(
 console.log(`    ${_cFgGreen}chart${_cReset}\t(re-generate csv files)`);
 console.log(`    ${_cFgGreen}dashboard${_cReset}\t(re-generate dashboard)`);
 console.log(
+  `    ${_cFgGreen}email${_cReset}\t(email the dashboard to configured recipients)`
+);
+console.log(
   `    ${_cFgGreen}enrich${_cReset}\t(enrich historical data with PR predictions)`
 );
 console.log(

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "exec": "^0.2.1",
         "fs": "^0.0.1-security",
         "node-fetch": "^3.3.2",
+        "nodemailer": "^9.0.5",
         "path": "^0.12.7",
         "uuid": "^14.0.2"
       },
@@ -778,6 +779,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.5.tgz",
+      "integrity": "sha512-wvjiKvjczmsN7U/8006JOdXubgBk2XFAbioDMbT+sM7cPs0QrhJTa6KBRX7P5REGGkDcLUz/EarWidb8G8C1jQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/object-code": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "combine": "rm -rf .results_history/combined_results.json && node results-combiner.js",
     "chart": "rm -rf .results_history/*.csv && node results-charter.js; node results-team-charter.js; node results-dashboard.js",
     "dashboard": "node results-dashboard.js",
+    "email": "node email-dashboard.js",
     "reindex": "node results-reindexer.js",
     "cleanup": "node results-cache-cleanup.js",
     "enrich": "node results-enrich.js",
@@ -45,6 +46,7 @@
     "exec": "^0.2.1",
     "fs": "^0.0.1-security",
     "node-fetch": "^3.3.2",
+    "nodemailer": "^9.0.5",
     "path": "^0.12.7",
     "uuid": "^14.0.2"
   },

--- a/results-dashboard.js
+++ b/results-dashboard.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { exec } = require('child_process');
+const { sendDashboardEmail } = require('./email-dashboard');
 const { WEIGHTS } = require('./score');
 
 const resultsDir = path.join(__dirname, '.results_history');
@@ -2801,3 +2802,17 @@ const openCmd =
       ? 'start'
       : 'xdg-open';
 exec(`${openCmd} "${outputFile}"`);
+
+// Email the portable dashboard to the configured recipients. Opt-in, and never
+// fatal — a delivery problem must not fail a run that already wrote the report.
+const firstPeriod = dashboardData.periods[0];
+const lastPeriod = dashboardData.periods[dashboardData.periods.length - 1];
+
+sendDashboardEmail({
+  startDate: firstPeriod?.startDate,
+  endDate: lastPeriod?.endDate,
+  periods: dashboardData.periods.length,
+  generatedAt: new Date().toISOString().split('T')[0],
+}).catch(error => {
+  console.warn(`Failed to email the dashboard: ${error.message}`);
+});

--- a/sample-configs/treering.json
+++ b/sample-configs/treering.json
@@ -118,7 +118,21 @@
     "AI Bots"
   ],
   "tokens": {
-    "github": "ghp_XXXXXX"
+    "github": "ghp_XXXXXX",
+    "smtp": {
+      "user": "reports@treering.com",
+      "pass": "XXXXXXXXXXXXXXXX"
+    }
+  },
+  "email": {
+    "to": ["reports@treering.com"],
+    "from": "Repo Hero <reports@treering.com>",
+    "subject": "Repo Hero Dashboard — {range}",
+    "compress": true,
+    "smtp": {
+      "host": "smtp.gmail.com",
+      "port": 587
+    }
   },
   "commitsPerPullRequest": 12.5
 }


### PR DESCRIPTION
## Summary

Adds an optional `email` block to `config.json` that attaches the generated `dashboard.html` and sends it to one or more recipients. The dashboard still opens in the browser exactly as before — emailing is layered on top, so a scheduled `npm start` doubles as a recurring report.

## Configuration

Credentials sit under `tokens` alongside the existing `tokens.github`:

```jsonc
{
  "tokens": {
    "smtp": {
      "user": "reports@yourcompany.com",
      "pass": "xxxxxxxxxxxxxxxx"
    }
  },
  "email": {
    "to": ["lead@yourcompany.com", "vp@yourcompany.com"],
    "cc": [],
    "bcc": [],
    "from": "Repo Hero <reports@yourcompany.com>",
    "subject": "Repo Hero Dashboard — {range}",
    "compress": false,
    "maxAttachmentMB": 20,
    "enabled": true,
    "smtp": { "host": "smtp.gmail.com", "port": 587 }
  }
}
```

Only `to` and `smtp.host` are genuinely required — `from` falls back to the authenticating account and `secure` is inferred from the port, so a working config is three lines.

- **Recipients** — `to`, `cc`, and `bcc` each accept a single address string or an array, bare (`you@company.com`) or with a display name (`You <you@company.com>`). Entries are trimmed, de-duplicated case-insensitively, and validated.
- **Subject placeholders** — `{range}`, `{startDate}`, `{endDate}`, `{periods}`, `{date}`.
- **TLS** — `secure` defaults to `true` on port 465 (implicit TLS) and `false` on 587 or 25 (STARTTLS), and can be set explicitly to override.

## Attachment size

The dashboard inlines all of its data and assets, so it grows with your history — the current one here is **6.2 MB, which base64 inflates to 8.2 MB on the wire**, uncomfortably close to common message limits. Two guards address that:

- `"compress": true` attaches `dashboard.html.gz` instead. The dashboard is almost entirely text, so it compresses **17×** in practice (6.2 MB → 0.36 MB). macOS and Linux recipients can open it by double-clicking.
- `maxAttachmentMB` (default 20) refuses to send an oversized message rather than letting the SMTP server reject it mid-transfer, and explicitly suggests `compress` when it is off.

## Graceful degradation

Delivery is a convenience layered on a report that has already been written, so it never fails a run:

| Situation | Behavior |
|---|---|
| No `email` block | Unchanged behavior, completely silent |
| `"enabled": false` | Skipped silently |
| Missing/invalid recipients, host, or credentials | Every specific problem is named, run continues |
| Attachment over the limit | Skipped with a size report and a `compress` hint |
| Unreachable host, rejected login, mid-send failure | Warned, run continues |
| `dashboard.html` missing | Warned, run continues |

## Changes

- **`email-dashboard.js`** (new) — config resolution, recipient normalization and validation, subject templating, optional gzip, and SMTP delivery via nodemailer. Dual-purpose: imported by the pipeline and runnable directly.
- **`results-dashboard.js`** — after writing the file and launching the browser, sends the email with the real data range, period count, and generation date.
- **`npm run email`** — sends the dashboard already on disk without regenerating it or opening a browser, recovering the reporting period from `combined_results.json` so the subject matches what the pipeline would have sent.
- **Docs** — README features list, an "Email Delivery" configuration section, commands table, project structure, `help.js`, and a placeholder-only `sample-configs/treering.json` entry.
- **Dependency** — adds `nodemailer` (the de facto standard Node SMTP client; no native build step).

## Testing

Verified against a **purpose-built mock SMTP server** — **76 assertions**, all passing.

Unit level (54):
- Recipient normalization — single string, arrays, trimming, case-insensitive de-duplication, empty/null entries
- Address validation — bare, display-name, missing `@`, dotless domain, embedded spaces
- Subject templating — all placeholders, unknown placeholders left intact, `all time` fallback
- Config resolution — absent block, `enabled: false`, each missing required field reported individually, port and `secure` inference, explicit-override precedence, `from` fallback, defaults
- Live delivery — AUTH PLAIN credentials, envelope sender, envelope recipients including bcc, `To`/`Cc` headers, **`Bcc` correctly withheld from the message body**, RFC 2047 encoded subject, body contents
- Attachment — decoded MIME part matches `dashboard.html` **byte-for-byte**; gzip attachment **gunzips back to an identical file** and is verifiably smaller
- Degradation — oversized attachment refused with nothing sent, unreachable host resolves instead of throwing, unconfigured and invalid-config paths, missing `dashboard.html`

Pipeline level (22) — running the real `results-dashboard.js` as a subprocess:
- Unconfigured: dashboard written, exits clean, nothing sent, **no spurious warnings**
- Configured: dashboard written *and* emailed, both recipients in the envelope, gzip attachment present, and the subject carries the **actual** period count and date range read from real results
- SMTP down: dashboard still written, run still exits clean, failure reported
- Standalone CLI: sends without regenerating the dashboard, recovers the period metadata, reports compression savings
- `config.json` asserted restored byte-for-byte afterward

`prettier --write` reports no changes on every touched file.

## Backwards Compatibility

Fully additive. `config.json` files without an `email` block produce byte-identical behavior to before — verified explicitly as the first pipeline test case.
